### PR TITLE
Fixed formatting in the README markdown.

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Initialize a new Pubnub instance.
         // please goto the end of this file see the implementations of ParseResponse and ParseErrorResponse
 ```
 
-#### Subsribe
+#### Subscribe
 
 ```go
         //Init pubnub instance


### PR DESCRIPTION
The markdown on the Go package was not formatting in GitHub, and was making it very hard to read the examples. I modified it and added syntax highlighting for the example code.
