### PR TITLE
Fix a requestWorker http client data race

### DIFF
--- a/messaging/request_worker.go
+++ b/messaging/request_worker.go
@@ -123,8 +123,8 @@ type workerResponse struct {
 }
 
 func (w *requestWorker) Client() *http.Client {
-	w.TransportMu.RLock()
-	defer w.TransportMu.RUnlock()
+	w.TransportMu.Lock()
+	defer w.TransportMu.Unlock()
 
 	if w.Transport == nil {
 		logInfof("%s: Initializing new transport", w.Name)

--- a/messaging/tests/pubnubClientConcurrency_test.go
+++ b/messaging/tests/pubnubClientConcurrency_test.go
@@ -1,0 +1,37 @@
+package tests
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/pubnub/go/messaging"
+)
+
+const (
+	numGrants = 3
+	ttl       = 3
+	authKey   = "authKey"
+	channel   = "channel"
+)
+
+func TestPubnubGrantSubscribeParallelUnsafe(t *testing.T) {
+	wg := sync.WaitGroup{}
+	pubnub := messaging.NewPubnub(PubKey, SubKey, SecKey, "", false, "")
+
+	for j := 0; j < numGrants; j++ {
+		wg.Add(1)
+		go func(j int) {
+			defer wg.Done()
+			callback, err := make(chan []byte), make(chan []byte)
+
+			go pubnub.GrantSubscribe(channel, true, true, ttl, authKey, callback, err)
+			select {
+			case <-callback:
+			case <-err:
+			case <-messaging.SubscribeTimeout():
+			}
+		}(j)
+	}
+	wg.Wait()
+
+}


### PR DESCRIPTION
requestWorker.Client is writing to it's internal Transport variable, therefore it needs to call TransportMu.Lock() rather than transport.RLock(). Running the added test with -race turned on identifies the data race.

`go test -race -run TestPubnubGrantSubscribeParallelUnsafe
==================
WARNING: DATA RACE
Read by goroutine 16:
  github.com/pubnub/go/messaging.(*requestWorker).Client()
      /home/aplunk/go_workspace/src/github.com/pubnub/go/messaging/request_worker.go:129 +0xcd
  github.com/pubnub/go/messaging.(*requestWorker).InvokeRequest.func1()
      /home/aplunk/go_workspace/src/github.com/pubnub/go/messaging/request_worker.go:174 +0xdf

Previous write by goroutine 14:
  github.com/pubnub/go/messaging.(*requestWorker).Client()
      /home/aplunk/go_workspace/src/github.com/pubnub/go/messaging/request_worker.go:153 +0x830
  github.com/pubnub/go/messaging.(*requestWorker).InvokeRequest.func1()
      /home/aplunk/go_workspace/src/github.com/pubnub/go/messaging/request_worker.go:174 +0xdf
`