### PR TITLE
Remove logger mutex.

### DIFF
--- a/messaging/helpers.go
+++ b/messaging/helpers.go
@@ -90,22 +90,13 @@ func hasNonPresenceChannels(channelsString string) bool {
 }
 
 func logErrorf(format string, v ...interface{}) {
-	logMu.Lock()
-	defer logMu.Unlock()
-
 	errorLogger.Output(2, fmt.Sprintf(format, v...))
 }
 
 func logInfof(format string, v ...interface{}) {
-	logMu.Lock()
-	defer logMu.Unlock()
-
 	infoLogger.Output(2, fmt.Sprintf(format, v...))
 }
 
 func logInfoln(v ...interface{}) {
-	logMu.Lock()
-	defer logMu.Unlock()
-
 	infoLogger.Output(2, fmt.Sprintln(v...))
 }

--- a/messaging/pubnub.go
+++ b/messaging/pubnub.go
@@ -196,9 +196,6 @@ var (
 
 	// Logger for warn messages
 	warnLogger *log.Logger
-
-	// logMutex
-	logMu sync.Mutex
 )
 
 var (
@@ -359,10 +356,8 @@ func SetNonSubscribeTransport(transport http.RoundTripper) {
 // returns the pointer to Pubnub instance.
 func NewPubnub(publishKey string, subscribeKey string, secretKey string, cipherKey string, sslOn bool, customUuid string) *Pubnub {
 	initLogging()
-	logMu.Lock()
 	infoLogger.Println(fmt.Sprintf("Pubnub Init, %s", VersionInfo()))
 	infoLogger.Println(fmt.Sprintf("OS: %s", runtime.GOOS))
-	logMu.Unlock()
 
 	newPubnub := &Pubnub{}
 	newPubnub.origin = origin
@@ -387,9 +382,7 @@ func NewPubnub(publishKey string, subscribeKey string, secretKey string, cipherK
 		newPubnub.origin = "http://" + newPubnub.origin
 	}
 
-	logMu.Lock()
 	infoLogger.Println(fmt.Sprintf("Origin: %s", newPubnub.origin))
-	logMu.Unlock()
 	//Generate the uuid is custmUuid is not provided
 	newPubnub.SetUUID(customUuid)
 	newPubnub.publishCounter = 0
@@ -411,8 +404,6 @@ var once sync.Once
 
 // initLogging initaites the log file if loggingEnabled is true
 func initLogging() {
-	logMu.Lock()
-	defer logMu.Unlock()
 	onceBody := func() {
 		infoLogger = log.New(logfileWriter, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile)
 		errorLogger = log.New(logfileWriter, "ERROR: ", log.Ldate|log.Ltime|log.Lshortfile)
@@ -514,9 +505,7 @@ func (pub *Pubnub) SetUUID(val string) {
 		if err == nil {
 			pub.uuid = url.QueryEscape(uuid)
 		} else {
-			logMu.Lock()
 			errorLogger.Println(err.Error())
-			logMu.Unlock()
 		}
 	} else {
 		pub.uuid = url.QueryEscape(val)
@@ -1097,14 +1086,10 @@ func (pub *Pubnub) executePam(entity, requestURL string,
 
 		if err != nil {
 			message = err.Error()
-			logMu.Lock()
 			errorLogger.Println(fmt.Sprintf("PAM Error: %s", message))
-			logMu.Unlock()
 		} else {
 			message = fmt.Sprintf("%s", value)
-			logMu.Lock()
 			errorLogger.Println(fmt.Sprintf("PAM Error: responseCode %d, message %s", responseCode, message))
-			logMu.Unlock()
 		}
 
 		if strings.TrimSpace(entity) == "" {
@@ -1162,16 +1147,12 @@ func (pub *Pubnub) executeTime(callbackChannel chan []byte, errorChannel chan []
 	value, _, err := pub.httpRequest(timeURL, nonSubscribeTrans)
 
 	if err != nil {
-		logMu.Lock()
 		errorLogger.Println(fmt.Sprintf("Time Error: %s", err.Error()))
-		logMu.Unlock()
 		sendResponseWithoutChannel(errorChannel, err.Error())
 	} else {
 		_, _, _, errJSON := ParseJSON(value, pub.cipherKey)
 		if errJSON != nil && strings.Contains(errJSON.Error(), invalidJSON) {
-			logMu.Lock()
 			errorLogger.Println(fmt.Sprintf("Time Error: %s", errJSON.Error()))
-			logMu.Unlock()
 			sendResponseWithoutChannel(errorChannel, err.Error())
 			if count < maxRetries {
 				count++
@@ -1198,9 +1179,7 @@ func (pub *Pubnub) sendPublishRequest(channel, publishURLString string,
 
 	u := &url.URL{Path: string(jsonBytes)}
 	encodedPath := u.String()
-	logMu.Lock()
 	infoLogger.Println(fmt.Sprintf("Publish: json: %s, encoded: %s", string(jsonBytes), encodedPath))
-	logMu.Unlock()
 
 	publishURL := fmt.Sprintf("%s%s", publishURLString, encodedPath)
 	publishURL = fmt.Sprintf("%s?%s&uuid=%s%s", publishURL,
@@ -1215,9 +1194,7 @@ func (pub *Pubnub) sendPublishRequest(channel, publishURLString string,
 	counter := strconv.FormatUint(pub.publishCounter, 10)
 	pub.publishCounterMu.Unlock()
 
-	logMu.Lock()
 	infoLogger.Println(fmt.Sprintf("Publish counter: %s", counter))
-	logMu.Unlock()
 
 	publishURL = fmt.Sprintf("%s&seqn=%s", publishURL, counter)
 
@@ -1242,33 +1219,23 @@ func (pub *Pubnub) sendPublishRequest(channel, publishURLString string,
 					sendErrorResponseExtended(errorChannel, channel, string(value), strconv.Itoa(responseCode))
 				}
 			} else {
-				logMu.Lock()
 				errorLogger.Println(fmt.Sprintf("Publish Error: %s", errJSON.Error()))
-				logMu.Unlock()
 				sendErrorResponseExtended(errorChannel, channel, string(value), strconv.Itoa(responseCode))
 			}
 		} else if (err != nil) && (responseCode > 0) {
-			logMu.Lock()
 			errorLogger.Println(fmt.Sprintf("Publish Failed: %s, ResponseCode: %d", err.Error(), responseCode))
-			logMu.Unlock()
 			sendErrorResponseExtended(errorChannel, channel, err.Error(), strconv.Itoa(responseCode))
 		} else if err != nil {
-			logMu.Lock()
 			errorLogger.Println(fmt.Sprintf("Publish Failed: %s", err.Error()))
-			logMu.Unlock()
 			sendErrorResponse(errorChannel, channel, err.Error())
 		} else {
-			logMu.Lock()
 			errorLogger.Println(fmt.Sprintf("Publish Failed: ResponseCode: %d", responseCode))
-			logMu.Unlock()
 			sendErrorResponseExtended(errorChannel, channel, publishFailed, strconv.Itoa(responseCode))
 		}
 	} else {
 		_, _, _, errJSON := ParseJSON(value, pub.cipherKey)
 		if errJSON != nil && strings.Contains(errJSON.Error(), invalidJSON) {
-			logMu.Lock()
 			errorLogger.Println(fmt.Sprintf("Publish Error: %s", errJSON.Error()))
-			logMu.Unlock()
 			sendErrorResponse(errorChannel, channel, errJSON.Error())
 		} else {
 			callbackChannel <- value
@@ -1280,9 +1247,7 @@ func encodeURL(urlString string) string {
 	var reqURL *url.URL
 	reqURL, urlErr := url.Parse(urlString)
 	if urlErr != nil {
-		logMu.Lock()
 		errorLogger.Println(fmt.Sprintf("Url encoding error: %s", urlErr.Error()))
-		logMu.Unlock()
 		return urlString
 	}
 	q := reqURL.Query()
@@ -1295,9 +1260,7 @@ func encodeURL(urlString string) string {
 // Returns false is the message is acceptable.
 func invalidMessage(message interface{}) bool {
 	if message == nil {
-		logMu.Lock()
 		warnLogger.Println(fmt.Sprintf("Message nil"))
-		logMu.Unlock()
 		return true
 	}
 
@@ -1334,9 +1297,7 @@ func invalidChannel(channel string, c chan<- []byte) bool {
 
 	for i := 0; i < len(channelArray); i++ {
 		if strings.TrimSpace(channelArray[i]) == "" {
-			logMu.Lock()
 			warnLogger.Println(fmt.Sprintf("Channel empty"))
-			logMu.Unlock()
 			c <- []byte(fmt.Sprintf("Invalid Channel: %s", channel))
 			return true
 		}
@@ -1426,9 +1387,7 @@ func (pub *Pubnub) PublishExtendedWithMeta(channel string, message, meta interfa
 	checkCallbackNil(errorChannel, true, "Publish")
 
 	if pub.publishKey == "" {
-		logMu.Lock()
 		warnLogger.Println(fmt.Sprintf("Publish key empty"))
-		logMu.Unlock()
 		sendErrorResponse(errorChannel, channel, "Publish key required.")
 		return
 	}
@@ -1487,9 +1446,7 @@ func (pub *Pubnub) PublishExtendedWithMeta(channel string, message, meta interfa
 			//Encrypt and Serialize
 			jsonEncBytes, errEnc := json.Marshal(EncryptString(pub.cipherKey, fmt.Sprintf("%s", jsonSerialized)))
 			if errEnc != nil {
-				logMu.Lock()
 				errorLogger.Println(fmt.Sprintf("Publish error: %s", errEnc.Error()))
-				logMu.Unlock()
 				sendErrorResponse(errorChannel, channel, fmt.Sprintf("error in serializing: %s", errEnc))
 			} else {
 				pub.sendPublishRequest(channel, publishURLBuffer.String(),
@@ -1566,9 +1523,7 @@ func (pub *Pubnub) sendSuccessResponse(channels, groups string, response []byte)
 	for _, itemName := range splitItems(channels) {
 		channel, found := pub.channels.Get(itemName)
 		if !found {
-			logMu.Lock()
 			errorLogger.Printf("Channel '%s' not found\n", itemName)
-			logMu.Unlock()
 		}
 
 		channel.SuccessChannel <- response
@@ -1577,9 +1532,7 @@ func (pub *Pubnub) sendSuccessResponse(channels, groups string, response []byte)
 	for _, itemName := range splitItems(groups) {
 		group, found := pub.channels.Get(itemName)
 		if !found {
-			logMu.Lock()
 			errorLogger.Printf("Group '%s' not found\n", itemName)
-			logMu.Unlock()
 		}
 
 		group.SuccessChannel <- response
@@ -1593,9 +1546,7 @@ func sendSuccessResponseToChannel(channel chan<- []byte, items,
 
 	value := strings.Replace(response, presenceSuffix, "", -1)
 
-	logMu.Lock()
 	infoLogger.Println(fmt.Sprintf("Response value without channel: %s", value))
-	logMu.Unlock()
 
 	for i := 0; i < ln; i++ {
 		if channel != nil {
@@ -1608,9 +1559,7 @@ func sendSuccessResponseToChannel(channel chan<- []byte, items,
 func sendResponseWithoutChannel(channel chan<- []byte, response string) {
 	value := fmt.Sprintf("[0, \"%s\"]", response)
 
-	logMu.Lock()
 	infoLogger.Println(fmt.Sprintf("Response value without channel: %s", value))
-	logMu.Unlock()
 
 	if channel != nil {
 		channel <- []byte(value)
@@ -1790,9 +1739,7 @@ func (pub *Pubnub) checkForTimeoutAndRetries(err error) (bool, bool) {
 		pub.sleepForAWhile(true)
 		message := fmt.Sprintf("Error %s, Retry count: %s", err.Error(), strconv.Itoa(retryCountLocal))
 
-		logMu.Lock()
 		errorLogger.Println(message)
-		logMu.Unlock()
 
 		pub.sendSubscribeErrorExtended(subChannels, subChannelGroups,
 			err.Error(), message, responseAsIsError)
@@ -1801,9 +1748,7 @@ func (pub *Pubnub) checkForTimeoutAndRetries(err error) (bool, bool) {
 		pub.sleepForAWhile(false)
 		message := strconv.Itoa(retryCountLocal)
 
-		logMu.Lock()
 		errorLogger.Println(fmt.Sprintf("%s %s:", err.Error(), message))
-		logMu.Unlock()
 
 		pub.sendSubscribeError(subChannels, subChannelGroups, message, responseTimedOut)
 
@@ -1813,9 +1758,7 @@ func (pub *Pubnub) checkForTimeoutAndRetries(err error) (bool, bool) {
 		pub.sleepForAWhile(true)
 		message := strconv.Itoa(retryCountLocal)
 
-		logMu.Lock()
 		errorLogger.Println(fmt.Sprintf("%s %s:", err.Error(), message))
-		logMu.Unlock()
 
 		pub.sendSubscribeError(subChannels, subChannelGroups, message, responseInternetConnIssues)
 		bRet = true
@@ -1889,9 +1832,7 @@ func (pub *Pubnub) retryLoop() {
 			retryCountMu.RUnlock()
 
 			if (err != nil) && (responseCode != 403) && (retryCountLocal <= 0) {
-				logMu.Lock()
 				errorLogger.Println(fmt.Sprintf("%s, response code: %d:", err.Error(), responseCode))
-				logMu.Unlock()
 
 				pub.checkForTimeoutAndRetries(err)
 				pub.CloseExistingConnection()
@@ -1951,9 +1892,7 @@ func (pub *Pubnub) createPresenceHeartbeatURL() string {
 	pub.RUnlock()
 
 	if err != nil {
-		logMu.Lock()
 		errorLogger.Println(fmt.Sprintf("createPresenceHeartbeatURL %s", err.Error()))
-		logMu.Unlock()
 	} else {
 		userState := string(jsonSerialized)
 		if (strings.TrimSpace(userState) != "") && (userState != "null") {
@@ -1979,9 +1918,7 @@ func (pub *Pubnub) runPresenceHeartbeat() {
 	pub.RUnlock()
 
 	if isPresenceHeartbeatRunning {
-		logMu.Lock()
 		infoLogger.Println(fmt.Sprintf("Presence heartbeat already running"))
-		logMu.Unlock()
 
 		return
 	}
@@ -2005,9 +1942,7 @@ func (pub *Pubnub) runPresenceHeartbeat() {
 			pub.isPresenceHeartbeatRunning = false
 			pub.Unlock()
 
-			logMu.Lock()
 			infoLogger.Println(fmt.Sprintf("Breaking out of presence heartbeat loop"))
-			logMu.Unlock()
 
 			pub.cancelPresenceHeartbeatWorker()
 			break
@@ -2019,18 +1954,12 @@ func (pub *Pubnub) runPresenceHeartbeat() {
 
 		if (responseCode != 200) || (err != nil) {
 			if err != nil {
-				logMu.Lock()
 				errorLogger.Println(fmt.Sprintf("presence heartbeat err %s", err.Error()))
-				logMu.Unlock()
 			} else {
-				logMu.Lock()
 				errorLogger.Println(fmt.Sprintf("presence heartbeat err responseCode %d", responseCode))
-				logMu.Unlock()
 			}
 		} else if string(value) != "" {
-			logMu.Lock()
 			infoLogger.Println(fmt.Sprintf("Presence Heartbeat %s", string(value)))
-			logMu.Unlock()
 		}
 		time.Sleep(time.Duration(pub.GetPresenceHeartbeatInterval()) * time.Second)
 	}
@@ -2150,9 +2079,7 @@ func (pub *Pubnub) startSubscribeLoop(channels, groups string,
 				// - 400/cg doesn't exist
 				// - 403/no permissions
 			} else if responseCode != 200 {
-				logMu.Lock()
 				errorLogger.Println(fmt.Sprintf("Server Error. Response code: %d:", responseCode))
-				logMu.Unlock()
 
 				if responseCode != 403 && responseCode != 400 {
 					pub.resetRetryAndSendResponse()
@@ -2247,9 +2174,7 @@ func (pub *Pubnub) createSubscribeURL(sentTimeToken, region string) (string, str
 		subscribeURLBuffer.WriteString("&filter-expr=")
 		encodedPath := url.QueryEscape(pub.FilterExpression())
 		encodedPathWithPlusReplaced := strings.Replace(encodedPath, "+", "%20", -1)
-		logMu.Lock()
 		infoLogger.Println(fmt.Sprintf("FilterExpression: %s, encoded: %s, enc2: %s", pub.FilterExpression(), encodedPath, encodedPathWithPlusReplaced))
-		logMu.Unlock()
 
 		subscribeURLBuffer.WriteString(encodedPathWithPlusReplaced)
 	}
@@ -2263,9 +2188,7 @@ func (pub *Pubnub) createSubscribeURL(sentTimeToken, region string) (string, str
 
 	jsonSerialized, err := json.Marshal(pub.userState)
 	if err != nil {
-		logMu.Lock()
 		errorLogger.Println(fmt.Sprintf("createSubscribeURL err: %s", err.Error()))
-		logMu.Unlock()
 	} else {
 		userState := string(jsonSerialized)
 		if (strings.TrimSpace(userState) != "") && (userState != "null") {
@@ -2350,9 +2273,7 @@ func (pub *Pubnub) handleSubscribeResponse(response []byte,
 			}
 		}
 	} else if errJSON != nil {
-		logMu.Lock()
 		errorLogger.Println(fmt.Sprintf("%s", errJSON.Error()))
-		logMu.Unlock()
 		channelNames, channelGroupNames := subEnvelope.getChannelsAndGroups()
 		chNames := ""
 		if len(channelNames) > 0 {
@@ -2364,9 +2285,7 @@ func (pub *Pubnub) handleSubscribeResponse(response []byte,
 			chGroupNames = strings.Join(channelGroupNames, ",")
 		}
 
-		logMu.Lock()
 		infoLogger.Println(fmt.Sprintf("chNames=%s\nchGroupNames=%s", chNames, chGroupNames))
-		logMu.Unlock()
 
 		pub.sendSubscribeError(chNames, chGroupNames, fmt.Sprintf("%s", errJSON),
 			responseAsIsError)
@@ -2404,11 +2323,9 @@ func (pub *Pubnub) handleSubscribeResponse(response []byte,
 
 		for i, message := range data {
 			if channelNames[i] == "" {
-				logMu.Lock()
 				errorLogger.Println(
 					fmt.Sprintf("Requested index %dout of range in %s. Raw response: %s",
 						i, channelNames, data))
-				logMu.Unlock()
 
 				continue
 			}
@@ -2496,26 +2413,22 @@ func (pub *Pubnub) parseMessagesAndSendCallbacks(msg subscribeMessage, timetoken
 		} else if !thirdChannelExist && !fourthChannelExist && !strings.HasSuffix(fourth, presenceSuffix) {
 			// Message should be ignored
 		} else {
-			logMu.Lock()
 			errorLogger.Println(
 				"Unable to handle four-element response, please contact PubNub support with error description:",
 				"\n3rd element:", third,
 				"\n4th element:", fourth,
 			)
-			logMu.Unlock()
 			pub.sendSubscribeError(subscribedChannels, subscribedGroups,
 				"Unable to handle response", responseAsIsError)
 		}
 	} else if third != fourth && thirdChannelGroupExist {
 		pub.sendSubscribeResponse(fourth, third, timetoken, channelGroupResponse, responseAsIs, message)
 	} else {
-		logMu.Lock()
 		errorLogger.Println(
 			"Unable to handle four-element response, please contact PubNub support with error description:",
 			"\n3rd element:", third,
 			"\n4th element:", fourth,
 		)
-		logMu.Unlock()
 		pub.sendSubscribeError(subscribedChannels, subscribedGroups,
 			"Unable to handle response", responseAsIsError)
 	}
@@ -2545,9 +2458,7 @@ func checkCallbackNil(channelToCheck chan<- []byte, isErrChannel bool, funcName 
 			message2 = "Error "
 		}
 		message := fmt.Sprintf("%sCallback is nil for %s", message2, funcName)
-		logMu.Lock()
 		errorLogger.Println(message)
-		logMu.Unlock()
 		panic(message)
 	}
 }
@@ -2923,17 +2834,13 @@ func (pub *Pubnub) Unsubscribe(channels string, callbackChannel, errorChannel ch
 
 			value, statusCode, err := pub.sendLeaveRequest(unsubscribeChannels, "")
 			if err != nil {
-				logMu.Lock()
 				errorLogger.Println(fmt.Sprintf("%s", err.Error()))
-				logMu.Unlock()
 
 				sendErrorResponse(errorChannel, unsubscribeChannels, err.Error())
 			} else if statusCode != 200 {
 				errorString := string(value)
 
-				logMu.Lock()
 				errorLogger.Println(fmt.Sprintf("%s", errorString))
-				logMu.Unlock()
 
 				sendErrorResponse(errorChannel, unsubscribeChannels, errorString)
 			} else {
@@ -2984,17 +2891,13 @@ func (pub *Pubnub) ChannelGroupUnsubscribe(groups string, callbackChannel,
 
 			value, statusCode, err := pub.sendLeaveRequest("", unsubscribeGroups)
 			if err != nil {
-				logMu.Lock()
 				errorLogger.Println(fmt.Sprintf("%s", err.Error()))
-				logMu.Unlock()
 
 				sendErrorResponse(errorChannel, unsubscribeGroups, err.Error())
 			} else if statusCode != 200 {
 				errorString := string(value)
 
-				logMu.Lock()
 				errorLogger.Println(fmt.Sprintf("%s", errorString))
-				logMu.Unlock()
 
 				sendErrorResponse(errorChannel, unsubscribeGroups, errorString)
 			} else {
@@ -3534,9 +3437,7 @@ func (pub *Pubnub) SetUserStateKeyVal(channel, key, val string,
 	}
 
 	if err != nil {
-		logMu.Lock()
 		errorLogger.Println(fmt.Sprintf("SetUserStateKeyVal err: %s", err.Error()))
-		logMu.Unlock()
 		sendErrorResponseExtended(errorChannel, channel, invalidUserStateMap, err.Error())
 		return
 	}
@@ -3738,9 +3639,7 @@ func getData(rawData interface{}, cipherKey string) string {
 		if err == nil {
 			return string(jsonData)
 		}
-		logMu.Lock()
 		errorLogger.Println(fmt.Sprintf("%s", err.Error()))
-		logMu.Unlock()
 		return fmt.Sprintf("%s", vv[0])
 	case []interface{}:
 		retval := parseInterface(vv, cipherKey)
@@ -3779,9 +3678,7 @@ func parseInterface(vv []interface{}, cipherKey string) string {
 				intf = u
 				unescapeVal, unescapeErr := url.QueryUnescape(intf.(string))
 				if unescapeErr != nil {
-					logMu.Lock()
 					errorLogger.Println(fmt.Sprintf("unescape :%s", unescapeErr.Error()))
-					logMu.Unlock()
 
 					vv[i] = intf
 				} else {
@@ -3797,9 +3694,7 @@ func parseInterface(vv []interface{}, cipherKey string) string {
 		if err == nil {
 			return string(jsonData)
 		}
-		logMu.Lock()
 		errorLogger.Println(fmt.Sprintf("parseInterface: %s", err.Error()))
-		logMu.Unlock()
 
 		return fmt.Sprintf("%s", vv)
 	}
@@ -3897,15 +3792,11 @@ func ParseSubscribeResponse(rawResponse []byte, cipherKey string) (
 	//messages [][]byte, channels, groups []string, timetoken, region string, err error) {
 	res := subscribeEnvelope{}
 	if err := json.Unmarshal(rawResponse, &res); err != nil {
-		logMu.Lock()
 		errorLogger.Println(fmt.Sprintf("Invalid JSON:%s, err %s", string(rawResponse), err.Error()))
-		logMu.Unlock()
 	} else {
-		logMu.Lock()
 		infoLogger.Println(fmt.Sprintf("res.Messages count, %d", len(res.Messages)))
 		infoLogger.Println(fmt.Sprintf("TimetokenMeta Region, %d", res.TimetokenMeta.Region))
 		infoLogger.Println(fmt.Sprintf("TimetokenMeta Timestamp: %s", res.TimetokenMeta.Timetoken))
-		logMu.Unlock()
 		timetoken = string(res.TimetokenMeta.Timetoken)
 		region = strconv.Itoa(res.TimetokenMeta.Region)
 
@@ -3918,9 +3809,7 @@ func ParseSubscribeResponse(rawResponse []byte, cipherKey string) (
 		err = json.Unmarshal(rawResponse, &response)
 
 		if err != nil {
-			logMu.Lock()
 			errorLogger.Println(fmt.Sprintf("Invalid json:%s", string(rawResponse)))
-			logMu.Unlock()
 
 			err = fmt.Errorf(invalidJSON)
 			return

--- a/messaging/subscribe_response.go
+++ b/messaging/subscribe_response.go
@@ -50,7 +50,6 @@ func (env *subscribeEnvelope) getChannelsAndGroups() (channels, channelGroups []
 }
 
 func (msg *subscribeMessage) writeMessageLog(count int) {
-	logMu.Lock()
 	// start logging
 	infoLogger.Println(fmt.Sprintf("-----Message %d-----", count))
 	infoLogger.Println(fmt.Sprintf("Channel, %s", msg.Channel))
@@ -78,6 +77,4 @@ func (msg *subscribeMessage) writeMessageLog(count int) {
 		infoLogger.Println(fmt.Sprintf("UserMetadata, not converted to string"))
 	}
 	// end logging
-
-	logMu.Unlock()
 }


### PR DESCRIPTION
Removed global logMu mutex to avoid contention among clients. 
Additional reading:
https://golang.org/pkg/log/#Logger
https://golang.org/pkg/sync/#Once