### PR TITLE
Improve performance of encodeNonASCIIChars

### DIFF
--- a/messaging/pubnub.go
+++ b/messaging/pubnub.go
@@ -4031,6 +4031,28 @@ func encodeNonASCIIChars(message string) string {
 	return encodedString
 }
 
+func encodeNonASCIIChars2(message string) string {
+	runeOfMessage := []rune(message)
+	lenOfRune := len(runeOfMessage)
+	encodedString := bytes.NewBuffer(make([]byte, 0, lenOfRune))
+	for i := 0; i < lenOfRune; i++ {
+		intOfRune := uint16(runeOfMessage[i])
+		if intOfRune > 127 {
+			hexOfRune := strconv.FormatUint(uint64(intOfRune), 16)
+			dataLen := len(hexOfRune)
+			paddingNum := 4 - dataLen
+			encodedString.WriteString(`\u`)
+			for i := 0; i < paddingNum; i++ {
+				encodedString.WriteString("0")
+			}
+			encodedString.WriteString(hexOfRune)
+		} else {
+			encodedString.WriteString(string(runeOfMessage[i]))
+		}
+	}
+	return encodedString.String()
+}
+
 // EncryptString creates the base64 encoded encrypted string using the cipherKey.
 // It accepts the following parameters:
 // cipherKey: cipher key to use to encrypt.

--- a/messaging/pubnub.go
+++ b/messaging/pubnub.go
@@ -4011,29 +4011,6 @@ func GenUuid() (string, error) {
 func encodeNonASCIIChars(message string) string {
 	runeOfMessage := []rune(message)
 	lenOfRune := len(runeOfMessage)
-	encodedString := ""
-	for i := 0; i < lenOfRune; i++ {
-		intOfRune := uint16(runeOfMessage[i])
-		if intOfRune > 127 {
-			hexOfRune := strconv.FormatUint(uint64(intOfRune), 16)
-			dataLen := len(hexOfRune)
-			paddingNum := 4 - dataLen
-			prefix := ""
-			for i := 0; i < paddingNum; i++ {
-				prefix += "0"
-			}
-			hexOfRune = prefix + hexOfRune
-			encodedString += bytes.NewBufferString(`\u` + hexOfRune).String()
-		} else {
-			encodedString += string(runeOfMessage[i])
-		}
-	}
-	return encodedString
-}
-
-func encodeNonASCIIChars2(message string) string {
-	runeOfMessage := []rune(message)
-	lenOfRune := len(runeOfMessage)
 	encodedString := bytes.NewBuffer(make([]byte, 0, lenOfRune))
 	for i := 0; i < lenOfRune; i++ {
 		intOfRune := uint16(runeOfMessage[i])

--- a/messaging/pubnub_test.go
+++ b/messaging/pubnub_test.go
@@ -154,14 +154,25 @@ func BenchmarkEncodeNonASCIIChars(b *testing.B) {
 	}
 }
 
-func BenchmarkEncodeNonASCIIChars2(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		encodeNonASCIIChars2(testMessage1)
-		encodeNonASCIIChars2(testMessage2)
+func TestEncodeNonASCIIChars(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    testMessage1,
+			expected: "PRISE EN MAIN - Le Figaro a pu approcher les nouveaux smartphones de Google. Voici nos premi\\u00e8res observations. Le premier \\u00absmartphone con\\u00e7u Google\\u00bb. Voil\\u00e0 comment a \\u00e9t\\u00e9 pr\\u00e9sent\\u00e9 mardi le Pixel mardi. Il ne s'agit pas tout \\u00e0 fait de la premi\\u00e8re",
+		},
+		{
+			input:    testMessage2,
+			expected: testMessage2, // no non-ascii characters here, so the string should be unchanged
+		},
+		{
+			input:    "",
+			expected: "",
+		},
 	}
-}
-
-func TestEncodeNonASCIIChars2(t *testing.T) {
-	assert.Equal(t, encodeNonASCIIChars(testMessage1), encodeNonASCIIChars2(testMessage1))
-	assert.Equal(t, encodeNonASCIIChars(testMessage2), encodeNonASCIIChars2(testMessage2))
+	for _, tc := range cases {
+		assert.Equal(t, encodeNonASCIIChars(tc.input), tc.expected)
+	}
 }

--- a/messaging/pubnub_test.go
+++ b/messaging/pubnub_test.go
@@ -141,3 +141,27 @@ func TestGetSubscribeLoopActionListWithMultipleChannels(t *testing.T) {
 	<-await
 	assert.Equal(subscribeLoopDoNothing, action)
 }
+
+var (
+	testMessage1 = `PRISE EN MAIN - Le Figaro a pu approcher les nouveaux smartphones de Google. Voici nos premières observations. Le premier «smartphone conçu Google». Voilà comment a été présenté mardi le Pixel mardi. Il ne s'agit pas tout à fait de la première`
+	testMessage2 = `Everybody copies everybody. It doesn't mean they're "out of ideas" or "in a technological cul-de-sac" - or at least it doesn't necessarily mean that - it does mean they want to make money and keep users.`
+)
+
+func BenchmarkEncodeNonASCIIChars(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		encodeNonASCIIChars(testMessage1)
+		encodeNonASCIIChars(testMessage2)
+	}
+}
+
+func BenchmarkEncodeNonASCIIChars2(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		encodeNonASCIIChars2(testMessage1)
+		encodeNonASCIIChars2(testMessage2)
+	}
+}
+
+func TestEncodeNonASCIIChars2(t *testing.T) {
+	assert.Equal(t, encodeNonASCIIChars(testMessage1), encodeNonASCIIChars2(testMessage1))
+	assert.Equal(t, encodeNonASCIIChars(testMessage2), encodeNonASCIIChars2(testMessage2))
+}


### PR DESCRIPTION
We encountered a [performance issue](https://launchdarkly-pastebin.s3.amazonaws.com/pubnub-encodeNonASCIIChars-profile.pdf) under high load which seemed to be coming from the `encodeNonASCIIChars` function doing a lot of string concatenation.

In this PR, I offer an alternative implementation to the function, which I just called `encodeNonASCIIChars2`, which seems to fare better:

```
$ go test ./messaging -benchmem -bench BenchmarkEncodeNonASCIIChars
PASS
BenchmarkEncodeNonASCIIChars   	   10000       	    128796 ns/op       	   62258 B/op  	     947 allocs/op
BenchmarkEncodeNonASCIIChars2  	   50000       	     29767 ns/op       	    5434 B/op  	     455 allocs/op
ok     	github.com/pubnub/go/messaging 	3.100s
```

I left both functions in the code so that I could benchmark them side-by-side.  If you think this is the way to go, I can fix this PR so that the new version replaces the old version.

I didn't audit the rest of the code for unnecessary string concatenation, so there might be other quick wins here too.