### PR TITLE
Go 1.8 Fixes:  JSON path escaping during publish & encryption tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ go:
   - 1.7.1
   - 1.7.3
   - 1.7.4
+  - 1.8
 
 install:
   - mkdir -p $GOPATH/src/github.com/pubnub

--- a/gae/messaging/pubnub.go
+++ b/gae/messaging/pubnub.go
@@ -1050,6 +1050,18 @@ func (pub *Pubnub) executeTime(context context.Context, w http.ResponseWriter, r
 	}
 }
 
+// encodeJSONAsPathComponent properly encodes serialized JSON
+// for placement within a URI path
+func encodeJSONAsPathComponent(jsonBytes string) string {
+	u := &url.URL{Path: jsonBytes}
+	encodedPath := u.String()
+
+	// Go 1.8 inserts a ./ per RFC 3986 §4.2. Previous versions
+	// will be unaffected by this under the assumption that jsonBytes
+	// represents valid JSON
+	return strings.TrimLeft(encodedPath, "./")
+}
+
 // sendPublishRequest is the struct Pubnub's instance method that posts a publish request and
 // sends back the response to the channel.
 //
@@ -1067,8 +1079,7 @@ func (pub *Pubnub) sendPublishRequest(context context.Context,
 	storeInHistory, replicate bool, jsonBytes string, metaBytes []byte,
 	callbackChannel, errorChannel chan []byte) {
 
-	u := &url.URL{Path: string(jsonBytes)}
-	encodedPath := u.String()
+	encodedPath := encodeJSONAsPathComponent(jsonBytes)
 	log.Infof(context, fmt.Sprintf("Publish: json: %s, encoded: %s", string(jsonBytes), encodedPath))
 
 	publishURL := fmt.Sprintf("%s%s", publishURLString, encodedPath)
@@ -1093,9 +1104,7 @@ func (pub *Pubnub) sendPublishRequest(context context.Context,
 	publishURL = fmt.Sprintf("%s&seqn=%s", publishURL, counter)
 
 	if metaBytes != nil {
-		metaEncoded := &url.URL{Path: string(metaBytes)}
-		metaEncodedPath := metaEncoded.String()
-
+		metaEncodedPath := encodeJSONAsPathComponent(string(metaBytes))
 		publishURL = fmt.Sprintf("%s&meta=%s", publishURL, metaEncodedPath)
 	}
 

--- a/messaging/encryption_test.go
+++ b/messaging/encryption_test.go
@@ -22,7 +22,7 @@ func TestPad(t *testing.T) {
 	b := []byte(`{
 	"kind": "click",
 	"user": {"key" : "user@test.com"},
-	"creationDate": 2416012257208,
+	"creationDate": 9223372036854775808346,
 	"key": "54651fa39868621628000002",
 	"url": "http://www.google.com"
 	}`)
@@ -31,7 +31,7 @@ func TestPad(t *testing.T) {
 	jsonSerialized, _ := json.Marshal(badMsg)
 
 	actual := EncryptString("enigma", fmt.Sprintf("%s", jsonSerialized))
-	expected := "yzJ2MMyt8So18nNXm4m3Dl0XuYAOJFj2JXG8P3BGlCsDsqM44ReH15MRGbEkJZCSqgMiX1wUK44Qz8gsTcmGcZm/7KtOa+kRnvgDpNkTuBUrDqSjmYeuBLqRIEIfoGrRNljbFmP1W9Zv8iVbJMmovF+gmNNiIzlC3J9dHK51/OgW7s2EASMQJr3UJZ26PoFmmXY/wYN+2EyRnT4PBRCocQ=="
+	expected := "yzJ2MMyt8So18nNXm4m3Dqzb1G+as9LDqdlZ+p8iEGi358F5h25wmKrj9FTOPdMQ0TMy/Xhf3hS3+ZRUlv/zLD6/0Ns/c834HQMUmG+6DN9SQy9II3bkUGZu9Bn6Ng/ZmJTrHV7QnkLnjD+pGOHEvqrPEduR5pfA2n9mA3qQNhqFgnsIvffxGB0AqM57NdD3Tlr2ig8A2VI4Lh3DmX7f1Q=="
 
 	assert.Equal(expected, actual)
 }

--- a/messaging/pubnub.go
+++ b/messaging/pubnub.go
@@ -1174,7 +1174,7 @@ func (pub *Pubnub) sendPublishRequest(channel, publishURLString string,
 	callbackChannel, errorChannel chan []byte) {
 
 	u := &url.URL{Path: jsonBytes}
-	encodedPath := u.String()
+	encodedPath := u.EscapedPath()
 	pub.infoLogger.Printf("INFO: Publish: json: %s, encoded: %s", jsonBytes, encodedPath)
 
 	publishURL := fmt.Sprintf("%s%s", publishURLString, encodedPath)

--- a/messaging/pubnub.go
+++ b/messaging/pubnub.go
@@ -1174,7 +1174,12 @@ func (pub *Pubnub) sendPublishRequest(channel, publishURLString string,
 	callbackChannel, errorChannel chan []byte) {
 
 	u := &url.URL{Path: jsonBytes}
-	encodedPath := u.EscapedPath()
+	encodedPath := u.String()
+
+	// Go 1.8 inserts a ./ per RFC 3986 §4.2. Previous versions
+	// will be unaffected by this under the assumption that jsonBytes
+	// represents valid JSON
+	encodedPath = strings.TrimLeft(encodedPath, "./")
 	pub.infoLogger.Printf("INFO: Publish: json: %s, encoded: %s", jsonBytes, encodedPath)
 
 	publishURL := fmt.Sprintf("%s%s", publishURLString, encodedPath)

--- a/messaging/pubnub_test.go
+++ b/messaging/pubnub_test.go
@@ -843,7 +843,7 @@ func TestGetDataCipherSingle(t *testing.T) {
 		cipherKey:  "enigma",
 		infoLogger: log.New(ioutil.Discard, "", log.Ldate|log.Ltime|log.Lshortfile),
 	}
-	response := `["h5Uhyc8uf3h11w5C68QsVenCf7Llvdq5XWLa1RSgdfU=",14610686757083461,14610686757935083]`
+	response := `["h5Uhyc8uf3h11w5C68QsVenCf7Llvdq5XWLa1RSgdfU=",9223372036854775808346,10223372036854775808084]`
 	var contents = []byte(response)
 	var s interface{}
 	err := json.Unmarshal(contents, &s)
@@ -855,7 +855,7 @@ func TestGetDataCipherSingle(t *testing.T) {
 			if length > 0 {
 				msgStr := pubnub.parseInterface(vv, pubnub.cipherKey)
 				//pubnub.infoLogger.Printf(msgStr)
-				assert.Equal("[\"Test Message 5\",1.461068675708346e+16,1.4610686757935084e+16]", msgStr)
+				assert.Equal("[\"Test Message 5\",9.223372036854776e+21,1.0223372036854776e+22]", msgStr)
 			}
 		default:
 			assert.Fail("default fall through")
@@ -872,7 +872,7 @@ func TestGetDataSingle(t *testing.T) {
 		//cipherKey:  "enigma",
 		infoLogger: log.New(ioutil.Discard, "", log.Ldate|log.Ltime|log.Lshortfile),
 	}
-	response := "[\"Test Message 5\",14610686757083461,14610686757935083]"
+	response := "[\"Test Message 5\",9223372036854775808346,10223372036854775808084]"
 	var contents = []byte(response)
 	var s interface{}
 	err := json.Unmarshal(contents, &s)
@@ -881,7 +881,7 @@ func TestGetDataSingle(t *testing.T) {
 		switch vv := v.(type) {
 		case []interface{}:
 			msgStr := pubnub.parseInterface(vv, pubnub.cipherKey)
-			assert.Equal("[\"Test Message 5\",1.461068675708346e+16,1.4610686757935084e+16]", msgStr)
+			assert.Equal("[\"Test Message 5\",9.223372036854776e+21,1.0223372036854776e+22]", msgStr)
 		default:
 			assert.Fail("default fall through")
 		}
@@ -897,7 +897,7 @@ func TestGetDataCipherNonEncSingle(t *testing.T) {
 		cipherKey:  "enigma",
 		infoLogger: log.New(ioutil.Discard, "", log.Ldate|log.Ltime|log.Lshortfile),
 	}
-	response := "[\"Test Message 5\",14610686757083461,14610686757935083]"
+	response := "[\"Test Message 5\",9223372036854775808346,10223372036854775808084]"
 	var contents = []byte(response)
 	var s interface{}
 	err := json.Unmarshal(contents, &s)
@@ -909,7 +909,7 @@ func TestGetDataCipherNonEncSingle(t *testing.T) {
 			if length > 0 {
 				msgStr := pubnub.parseInterface(vv, pubnub.cipherKey)
 				//pubnub.infoLogger.Printf(msgStr)
-				assert.Equal("[\"Test Message 5\",1.461068675708346e+16,1.4610686757935084e+16]", msgStr)
+				assert.Equal("[\"Test Message 5\",9.223372036854776e+21,1.0223372036854776e+22]", msgStr)
 			}
 		default:
 			assert.Fail("default fall through")


### PR DESCRIPTION
As of Go 1.8, net/url is more RFC 3986 compliant and treats relative paths correctly:
[https://github.com/golang/go/blob/master/src/net/url/url.go#L748](https://github.com/golang/go/blob/master/src/net/url/url.go#L748)

The use of String() on a url.URL with the first component of the path being JSON will now always prepend a ./ to make it valid.

This PR just uses EscapedPath instead which seems to be the original intent of encoding the JSON as a path component anyway.

Also is a fix for how Go 1.8 now marshals numbers. Any number that is a decimal that looks like an int64 will be represented as such. The tests were using numbers within that range so I just upped them out of it.

Testing:
1.8 (darwin/amd64)
1.7.4 (linux/amd64)