### PR TITLE
Use ParseInt instead of Atoi

### DIFF
--- a/publish_request.go
+++ b/publish_request.go
@@ -45,7 +45,7 @@ type publishOpts struct {
 
 // PublishResponse is the response after the execution on Publish and Fire operations.
 type PublishResponse struct {
-	Timestamp int
+	Timestamp int64
 }
 
 type publishBuilder struct {
@@ -68,7 +68,7 @@ func newPublishResponse(jsonBytes []byte, status StatusResponse) (
 	if !ok {
 		return emptyPublishResponse, status, pnerr.NewResponseParsingError(fmt.Sprintf("Error unmarshalling response, %s %v", value[2], value), nil, nil)
 	}
-	timestamp, err := strconv.Atoi(timeString)
+	timestamp, err := strconv.ParseInt(timeString, 10, 64)
 	if err != nil {
 		return emptyPublishResponse, status, err
 	}


### PR DESCRIPTION
I have been trying out PubNub Go(lang) SDK for my WebRTC application. My app is mostly written in Go, and using gomobile to port it onto mobile devices.

When I was running a test on Android emulator, I noticed the following error message:

Error(3): strconv.Atoi: parsing "15459683276803507": value out of range

Which was coming from pubnub SDK's "Publish" method:

	_, _, err := sig.pn.Publish().Channel(sig.peerID).Message(msg).Execute()

https://github.com/pubnub/go/blob/95eafa32fad6b383c6393142bce8ce03a989643a/publish_request.go#L71

I believe, since the target Android architecture is arm v7 (32-bit), the strconv.Atoi() won't be able to parse the string of large integer. (should be replaced with strconv.parseInt() with an explicit bit-size)

The exact same problem occurred on Raspberry Pi, I confirmed.