### PR TITLE
Fix SetUUIDMetadata when no profile, email or name is set

### DIFF
--- a/objects_set_uuid_metadata.go
+++ b/objects_set_uuid_metadata.go
@@ -45,11 +45,11 @@ func newSetUUIDMetadataBuilderWithContext(pubnub *PubNub,
 
 // SetUUIDMetadataBody is the input to update user
 type SetUUIDMetadataBody struct {
-	Name       string                 `json:"name,omitEmpty"`
-	ExternalID string                 `json:"externalId,omitEmpty"`
-	ProfileURL string                 `json:"profileUrl,omitEmpty"`
-	Email      string                 `json:"email,omitEmpty"`
-	Custom     map[string]interface{} `json:"custom,omitEmpty"`
+	Name       string                 `json:"name,omitempty"`
+	ExternalID string                 `json:"externalId,omitempty"`
+	ProfileURL string                 `json:"profileUrl,omitempty"`
+	Email      string                 `json:"email,omitempty"`
+	Custom     map[string]interface{} `json:"custom,omitempty"`
 }
 
 func (b *setUUIDMetadataBuilder) UUID(uuid string) *setUUIDMetadataBuilder {

--- a/objects_set_uuid_metadata.go
+++ b/objects_set_uuid_metadata.go
@@ -45,11 +45,11 @@ func newSetUUIDMetadataBuilderWithContext(pubnub *PubNub,
 
 // SetUUIDMetadataBody is the input to update user
 type SetUUIDMetadataBody struct {
-	Name       string                 `json:"name"`
-	ExternalID string                 `json:"externalId"`
-	ProfileURL string                 `json:"profileUrl"`
-	Email      string                 `json:"email"`
-	Custom     map[string]interface{} `json:"custom"`
+	Name       string                 `json:"name,omitEmpty"`
+	ExternalID string                 `json:"externalId,omitEmpty"`
+	ProfileURL string                 `json:"profileUrl,omitEmpty"`
+	Email      string                 `json:"email,omitEmpty"`
+	Custom     map[string]interface{} `json:"custom,omitEmpty"`
 }
 
 func (b *setUUIDMetadataBuilder) UUID(uuid string) *setUUIDMetadataBuilder {


### PR DESCRIPTION
The REST API for SetUUIDMetadata allows those fields to be unset or null but validates that if they are set they are valid.
The Go SDK always sets those fields, resulting in calls such as this one to fail:

```go
s.pubnubClient.SetUUIDMetadata().UUID(userInfo.EmbarkUser.ExternalID.String()).Custom(pubnubUserInfoMap).Execute()
```

This should work, and the way to make this work is to add the `omitEmpty` option