### PR TITLE
Do not send empty optional parameters in objects

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
-*         @eng-sdk
-.github/* @eng-sdk
-README.md @docs-engineering-members
+*         @pubnub/eng-sdk
+README.md @pubnub/docs-engineering-members
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-*         @kleewho @crimsonred @raipubnub
-.github/* @parfeon @kleewho @crimsonred @raipubnub
-README.md @techwritermat @kazydek
+*         @eng-sdk
+.github/* @eng-sdk
+README.md @docs-engineering-members
 

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,6 +1,11 @@
 ---
-version: v7.0.0
+version: v7.0.1
 changelog:
+  - date: 2022-02-08
+    version: v7.0.1
+    changes:
+      - type: bug
+        text: "Omit empty optional parameters for UUID or channel metadata."
   - date: 2022-01-06
     version: v7.0.0
     changes:
@@ -696,7 +701,7 @@ sdks:
             distribution-type: package
             distribution-repository: GitHub
             package-name: Go
-            location: https://github.com/pubnub/go/releases/tag/v7.0.0
+            location: https://github.com/pubnub/go/releases/tag/v7.0.1
             requires:
               -
                 name: "Go"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v7.0.1
+February 08 2022
+
+#### Fixed
+- Omit empty optional parameters for UUID or channel metadata.
+
 ## v7.0.0
 January 06 2022
 

--- a/objects_set_channel_metadata.go
+++ b/objects_set_channel_metadata.go
@@ -45,9 +45,9 @@ func newSetChannelMetadataBuilderWithContext(pubnub *PubNub,
 
 // SetChannelMetadataBody is the input to update space
 type SetChannelMetadataBody struct {
-	Name        string                 `json:"name"`
-	Description string                 `json:"description"`
-	Custom      map[string]interface{} `json:"custom"`
+	Name        string                 `json:"name,omitempty"`
+	Description string                 `json:"description,omitempty"`
+	Custom      map[string]interface{} `json:"custom,omitempty"`
 }
 
 func (b *setChannelMetadataBuilder) Include(include []PNChannelMetadataInclude) *setChannelMetadataBuilder {

--- a/objects_set_channel_metadata_test.go
+++ b/objects_set_channel_metadata_test.go
@@ -65,6 +65,30 @@ func AssertSetChannelMetadata(t *testing.T, checkQueryParam, testContext bool) {
 
 }
 
+func TestExcludeInChannelMetadataBodyNotSetFields(t *testing.T) {
+	assert := assert.New(t)
+	pn := NewPubNub(NewDemoConfig())
+
+	o := newSetChannelMetadataBuilder(pn)
+
+	o.Channel("id0")
+	o.Name("name")
+
+	path, err := o.opts.buildPath()
+	assert.Nil(err)
+
+	h.AssertPathsEqual(t,
+		fmt.Sprintf("/v2/objects/%s/channels/%s", pn.Config.SubscribeKey, "id0"),
+		path, []int{})
+
+	body, err := o.opts.buildBody()
+	assert.Nil(err)
+
+	expectedBody := "{\"name\":\"name\"}"
+
+	assert.Equal(expectedBody, string(body))
+}
+
 func TestSetChannelMetadata(t *testing.T) {
 	AssertSetChannelMetadata(t, true, false)
 }

--- a/objects_set_uuid_metadata.go
+++ b/objects_set_uuid_metadata.go
@@ -45,11 +45,11 @@ func newSetUUIDMetadataBuilderWithContext(pubnub *PubNub,
 
 // SetUUIDMetadataBody is the input to update user
 type SetUUIDMetadataBody struct {
-	Name       string                 `json:"name"`
-	ExternalID string                 `json:"externalId"`
-	ProfileURL string                 `json:"profileUrl"`
-	Email      string                 `json:"email"`
-	Custom     map[string]interface{} `json:"custom"`
+	Name       string                 `json:"name,omitempty"`
+	ExternalID string                 `json:"externalId,omitempty"`
+	ProfileURL string                 `json:"profileUrl,omitempty"`
+	Email      string                 `json:"email,omitempty"`
+	Custom     map[string]interface{} `json:"custom,omitempty"`
 }
 
 func (b *setUUIDMetadataBuilder) UUID(uuid string) *setUUIDMetadataBuilder {

--- a/objects_set_uuid_metadata_test.go
+++ b/objects_set_uuid_metadata_test.go
@@ -67,6 +67,35 @@ func AssertSetUUIDMetadata(t *testing.T, checkQueryParam, testContext bool) {
 
 }
 
+func TestExcludeInUUIDMetadataBodyNotSetFields(t *testing.T) {
+	assert := assert.New(t)
+	pn := NewPubNub(NewDemoConfig())
+	custom := map[string]interface{}{
+		"a": "b",
+		"c": "d",
+	}
+
+	o := newSetUUIDMetadataBuilder(pn)
+	o.UUID("id0")
+	o.Name("name")
+	o.ExternalID("exturl")
+	o.Custom(custom)
+
+	path, err := o.opts.buildPath()
+	assert.Nil(err)
+
+	h.AssertPathsEqual(t,
+		fmt.Sprintf("/v2/objects/%s/uuids/%s", pn.Config.SubscribeKey, "id0"),
+		path, []int{})
+
+	body, err := o.opts.buildBody()
+	assert.Nil(err)
+
+	expectedBody := "{\"name\":\"name\",\"externalId\":\"exturl\",\"custom\":{\"a\":\"b\",\"c\":\"d\"}}"
+
+	assert.Equal(expectedBody, string(body))
+}
+
 func TestSetUUIDMetadata(t *testing.T) {
 	AssertSetUUIDMetadata(t, true, false)
 }

--- a/pubnub.go
+++ b/pubnub.go
@@ -14,7 +14,7 @@ import (
 // Default constants
 const (
 	// Version :the version of the SDK
-	Version = "7.0.0"
+	Version = "7.0.1"
 	// MaxSequence for publish messages
 	MaxSequence = 65535
 )


### PR DESCRIPTION
fix: Omit empty optional parameters for UUID or channel metadata