### PR TITLE
Send previously stored region when subscribing

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,6 +1,13 @@
 ---
-version: v7.0.1
+version: v7.0.2
 changelog:
+  - date: 2022-03-17
+    version: v7.0.2
+    changes:
+      - type: bug
+        text: "Send region on subscribe calls."
+      - type: bug
+        text: "Close idle connections to free up goroutines when closing PubNub."
   - date: 2022-02-08
     version: v7.0.1
     changes:
@@ -701,7 +708,7 @@ sdks:
             distribution-type: package
             distribution-repository: GitHub
             package-name: Go
-            location: https://github.com/pubnub/go/releases/tag/v7.0.1
+            location: https://github.com/pubnub/go/releases/tag/v7.0.2
             requires:
               -
                 name: "Go"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v7.0.2
+March 17 2022
+
+#### Fixed
+- Send region on subscribe calls.
+- Close idle connections to free up goroutines when closing PubNub.
+
 ## v7.0.1
 February 08 2022
 

--- a/pubnub.go
+++ b/pubnub.go
@@ -14,7 +14,7 @@ import (
 // Default constants
 const (
 	// Version :the version of the SDK
-	Version = "7.0.1"
+	Version = "7.0.2"
 	// MaxSequence for publish messages
 	MaxSequence = 65535
 )

--- a/subscription_manager.go
+++ b/subscription_manager.go
@@ -311,6 +311,7 @@ func (m *SubscriptionManager) startSubscribeLoop() {
 		m.Lock()
 		tt := m.timetoken
 		ctx := m.ctx
+		tr := m.region
 		m.Unlock()
 
 		opts := &subscribeOpts{
@@ -318,6 +319,7 @@ func (m *SubscriptionManager) startSubscribeLoop() {
 			Channels:         combinedChannels,
 			ChannelGroups:    combinedGroups,
 			Timetoken:        tt,
+			Region:           strconv.Itoa(int(tr)),
 			Heartbeat:        m.pubnub.Config.PresenceTimeout,
 			FilterExpression: m.pubnub.Config.FilterExpression,
 			ctx:              ctx,


### PR DESCRIPTION
fix: Send region on subscribe calls

fix: Close idle connections to free up goroutines when closing PubNub
