### PR TITLE
Close body and idle connections

### DIFF
--- a/pubnub.go
+++ b/pubnub.go
@@ -724,6 +724,7 @@ func (pn *PubNub) Destroy() {
 	pn.requestWorkers.Close()
 	pn.Config.Log.Println("after close requestWorkers")
 	pn.tokenManager.CleanUp()
+	pn.client.CloseIdleConnections()
 
 }
 

--- a/request.go
+++ b/request.go
@@ -273,6 +273,9 @@ func newRequest(method string, u *url.URL, body io.Reader, useHTTP2 bool) (*http
 
 func parseResponse(resp *http.Response, opts endpointOpts) ([]byte, StatusResponse, error) {
 	status := StatusResponse{}
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(resp.Body)
 
 	if (resp.StatusCode != 200) && (resp.StatusCode != 204) {
 		// Errors like 400, 403, 500


### PR DESCRIPTION
The image is the proof for the fix. On the left a goroutine analysis after the fix, on the right before. Test is the same 

```
func TestGrantTokenForTrace(t *testing.T) {
	println(strconv.Itoa(runtime.NumGoroutine()))
	for i := 0; i < 10; i++ {

		token, err := GenerateGrantToken(strconv.Itoa(i))
		if err == nil {
			t.Fail()
		}
		println(token)
		println(strconv.Itoa(runtime.NumGoroutine()))
	}
}
```

`GenerateGrantToken` is making one grant token call, and then destroys the PubNub client. The whole test takes around 10-12s and as you see on the right one of the `readLoop` goroutines is living for the whole duration of it. Next one is a little younger and so on. On the left all of them have comparable life time. 

![image](https://user-images.githubusercontent.com/872650/158627351-72dfd8ae-d8ab-4827-b342-24652bfbde12.png)
