### PR TITLE
Set default limit for object calls with context

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,6 +1,13 @@
 ---
-version: v7.0.2
+version: v7.0.3
 changelog:
+  - date: 2022-05-04
+    version: v7.0.3
+    changes:
+      - type: bug
+        text: "Set default limit for object calls with context."
+      - type: bug
+        text: "All channel groups management operations could double escape some  characters which could cause signature problems."
   - date: 2022-03-17
     version: v7.0.2
     changes:
@@ -707,7 +714,7 @@ sdks:
             distribution-type: package
             distribution-repository: GitHub
             package-name: Go
-            location: https://github.com/pubnub/go/releases/tag/v7.0.2
+            location: https://github.com/pubnub/go/releases/tag/v7.0.3
             requires:
               -
                 name: "Go"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v7.0.3
+May 04 2022
+
+#### Fixed
+- Set default limit for object calls with context.
+- All channel groups management operations could double escape some  characters which could cause signature problems.
+
 ## v7.0.2
 March 17 2022
 

--- a/objects_get_all_channel_metadata.go
+++ b/objects_get_all_channel_metadata.go
@@ -25,14 +25,7 @@ type getAllChannelMetadataBuilder struct {
 }
 
 func newGetAllChannelMetadataBuilder(pubnub *PubNub) *getAllChannelMetadataBuilder {
-	builder := getAllChannelMetadataBuilder{
-		opts: &getAllChannelMetadataOpts{
-			pubnub: pubnub,
-		},
-	}
-	builder.opts.Limit = getAllChannelMetadataLimitV2
-
-	return &builder
+	return newGetAllChannelMetadataBuilderWithContext(pubnub, pubnub.ctx)
 }
 
 func newGetAllChannelMetadataBuilderWithContext(pubnub *PubNub,
@@ -43,6 +36,7 @@ func newGetAllChannelMetadataBuilderWithContext(pubnub *PubNub,
 			ctx:    context,
 		},
 	}
+	builder.opts.Limit = getAllChannelMetadataLimitV2
 
 	return &builder
 }

--- a/objects_get_all_uuid_metadata.go
+++ b/objects_get_all_uuid_metadata.go
@@ -25,14 +25,7 @@ type getAllUUIDMetadataBuilder struct {
 }
 
 func newGetAllUUIDMetadataBuilder(pubnub *PubNub) *getAllUUIDMetadataBuilder {
-	builder := getAllUUIDMetadataBuilder{
-		opts: &getAllUUIDMetadataOpts{
-			pubnub: pubnub,
-		},
-	}
-	builder.opts.Limit = getAllUUIDMetadataLimitV2
-
-	return &builder
+	return newGetAllUUIDMetadataBuilderWithContext(pubnub, pubnub.ctx)
 }
 
 func newGetAllUUIDMetadataBuilderWithContext(pubnub *PubNub,
@@ -43,6 +36,7 @@ func newGetAllUUIDMetadataBuilderWithContext(pubnub *PubNub,
 			ctx:    context,
 		},
 	}
+	builder.opts.Limit = getAllUUIDMetadataLimitV2
 
 	return &builder
 }

--- a/objects_get_channel_members_v2.go
+++ b/objects_get_channel_members_v2.go
@@ -25,14 +25,7 @@ type getChannelMembersBuilderV2 struct {
 }
 
 func newGetChannelMembersBuilderV2(pubnub *PubNub) *getChannelMembersBuilderV2 {
-	builder := getChannelMembersBuilderV2{
-		opts: &getChannelMembersOptsV2{
-			pubnub: pubnub,
-		},
-	}
-	builder.opts.Limit = membersLimitV2
-
-	return &builder
+	return newGetChannelMembersBuilderV2WithContext(pubnub, pubnub.ctx)
 }
 
 func newGetChannelMembersBuilderV2WithContext(pubnub *PubNub,
@@ -43,6 +36,7 @@ func newGetChannelMembersBuilderV2WithContext(pubnub *PubNub,
 			ctx:    context,
 		},
 	}
+	builder.opts.Limit = membersLimitV2
 
 	return &builder
 }

--- a/objects_get_memberships_v2.go
+++ b/objects_get_memberships_v2.go
@@ -25,14 +25,7 @@ type getMembershipsBuilderV2 struct {
 }
 
 func newGetMembershipsBuilderV2(pubnub *PubNub) *getMembershipsBuilderV2 {
-	builder := getMembershipsBuilderV2{
-		opts: &getMembershipsOptsV2{
-			pubnub: pubnub,
-		},
-	}
-	builder.opts.Limit = membershipsLimitV2
-
-	return &builder
+	return newGetMembershipsBuilderV2WithContext(pubnub, pubnub.ctx)
 }
 
 func newGetMembershipsBuilderV2WithContext(pubnub *PubNub,
@@ -43,6 +36,7 @@ func newGetMembershipsBuilderV2WithContext(pubnub *PubNub,
 			ctx:    context,
 		},
 	}
+	builder.opts.Limit = membershipsLimitV2
 
 	return &builder
 }

--- a/objects_manage_channel_members_v2.go
+++ b/objects_manage_channel_members_v2.go
@@ -25,14 +25,7 @@ type manageChannelMembersBuilderV2 struct {
 }
 
 func newManageChannelMembersBuilderV2(pubnub *PubNub) *manageChannelMembersBuilderV2 {
-	builder := manageChannelMembersBuilderV2{
-		opts: &manageMembersOptsV2{
-			pubnub: pubnub,
-		},
-	}
-	builder.opts.Limit = manageMembersLimitV2
-
-	return &builder
+	return newManageChannelMembersBuilderV2WithContext(pubnub, pubnub.ctx)
 }
 
 func newManageChannelMembersBuilderV2WithContext(pubnub *PubNub,
@@ -43,6 +36,7 @@ func newManageChannelMembersBuilderV2WithContext(pubnub *PubNub,
 			ctx:    context,
 		},
 	}
+	builder.opts.Limit = manageMembersLimitV2
 
 	return &builder
 }

--- a/objects_manage_memberships_v2.go
+++ b/objects_manage_memberships_v2.go
@@ -25,14 +25,7 @@ type manageMembershipsBuilderV2 struct {
 }
 
 func newManageMembershipsBuilderV2(pubnub *PubNub) *manageMembershipsBuilderV2 {
-	builder := manageMembershipsBuilderV2{
-		opts: &manageMembershipsOptsV2{
-			pubnub: pubnub,
-		},
-	}
-	builder.opts.Limit = manageMembershipsLimitV2
-
-	return &builder
+	return newManageMembershipsBuilderV2WithContext(pubnub, pubnub.ctx)
 }
 
 func newManageMembershipsBuilderV2WithContext(pubnub *PubNub,
@@ -43,6 +36,7 @@ func newManageMembershipsBuilderV2WithContext(pubnub *PubNub,
 			ctx:    context,
 		},
 	}
+	builder.opts.Limit = manageMembershipsLimitV2
 
 	return &builder
 }

--- a/objects_remove_channel_members.go
+++ b/objects_remove_channel_members.go
@@ -25,14 +25,7 @@ type removeChannelMembersBuilder struct {
 }
 
 func newRemoveChannelMembersBuilder(pubnub *PubNub) *removeChannelMembersBuilder {
-	builder := removeChannelMembersBuilder{
-		opts: &removeChannelMembersOpts{
-			pubnub: pubnub,
-		},
-	}
-	builder.opts.Limit = removeChannelMembersLimit
-
-	return &builder
+	return newRemoveChannelMembersBuilderWithContext(pubnub, pubnub.ctx)
 }
 
 func newRemoveChannelMembersBuilderWithContext(pubnub *PubNub,
@@ -43,6 +36,7 @@ func newRemoveChannelMembersBuilderWithContext(pubnub *PubNub,
 			ctx:    context,
 		},
 	}
+	builder.opts.Limit = removeChannelMembersLimit
 
 	return &builder
 }

--- a/objects_remove_memberships.go
+++ b/objects_remove_memberships.go
@@ -25,14 +25,7 @@ type removeMembershipsBuilder struct {
 }
 
 func newRemoveMembershipsBuilder(pubnub *PubNub) *removeMembershipsBuilder {
-	builder := removeMembershipsBuilder{
-		opts: &removeMembershipsOpts{
-			pubnub: pubnub,
-		},
-	}
-	builder.opts.Limit = removeMembershipsLimit
-
-	return &builder
+	return newRemoveMembershipsBuilderWithContext(pubnub, pubnub.ctx)
 }
 
 func newRemoveMembershipsBuilderWithContext(pubnub *PubNub,
@@ -43,6 +36,7 @@ func newRemoveMembershipsBuilderWithContext(pubnub *PubNub,
 			ctx:    context,
 		},
 	}
+	builder.opts.Limit = removeMembershipsLimit
 
 	return &builder
 }

--- a/objects_set_channel_members.go
+++ b/objects_set_channel_members.go
@@ -25,14 +25,7 @@ type setChannelMembersBuilder struct {
 }
 
 func newSetChannelMembersBuilder(pubnub *PubNub) *setChannelMembersBuilder {
-	builder := setChannelMembersBuilder{
-		opts: &setChannelMembersOpts{
-			pubnub: pubnub,
-		},
-	}
-	builder.opts.Limit = setChannelMembersLimit
-
-	return &builder
+	return newSetChannelMembersBuilderWithContext(pubnub, pubnub.ctx)
 }
 
 func newSetChannelMembersBuilderWithContext(pubnub *PubNub,
@@ -43,6 +36,7 @@ func newSetChannelMembersBuilderWithContext(pubnub *PubNub,
 			ctx:    context,
 		},
 	}
+	builder.opts.Limit = setChannelMembersLimit
 
 	return &builder
 }

--- a/objects_set_memberships.go
+++ b/objects_set_memberships.go
@@ -25,14 +25,7 @@ type setMembershipsBuilder struct {
 }
 
 func newSetMembershipsBuilder(pubnub *PubNub) *setMembershipsBuilder {
-	builder := setMembershipsBuilder{
-		opts: &setMembershipsOpts{
-			pubnub: pubnub,
-		},
-	}
-	builder.opts.Limit = setMembershipsLimit
-
-	return &builder
+	return newSetMembershipsBuilderWithContext(pubnub, pubnub.ctx)
 }
 
 func newSetMembershipsBuilderWithContext(pubnub *PubNub,
@@ -43,6 +36,7 @@ func newSetMembershipsBuilderWithContext(pubnub *PubNub,
 			ctx:    context,
 		},
 	}
+	builder.opts.Limit = setMembershipsLimit
 
 	return &builder
 }

--- a/pubnub.go
+++ b/pubnub.go
@@ -14,7 +14,7 @@ import (
 // Default constants
 const (
 	// Version :the version of the SDK
-	Version = "7.0.2"
+	Version = "7.0.3"
 	// MaxSequence for publish messages
 	MaxSequence = 65535
 )

--- a/tests/e2e/where_now_test.go
+++ b/tests/e2e/where_now_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -54,14 +55,22 @@ func TestWhereNowNoUUID(t *testing.T) {
 
 	pn := pubnub.NewPubNub(config)
 	pn.Subscribe().Channels([]string{"ch1"}).Execute()
-	time.Sleep(2 * time.Second)
+	time.Sleep(500 * time.Millisecond)
 
-	res, _, err := pn.WhereNow().
-		Execute()
+	checkFor(assert, 4*time.Second, 500*time.Millisecond, func() error {
+		res, _, err := pn.WhereNow().
+			Execute()
 
-	assert.Nil(err)
+		if err != nil {
+			return err
+		}
 
-	assert.NotEqual(0, len(res.Channels))
+		if len(res.Channels) == 0 {
+			return errors.New("res.Channels can't be empty")
+		}
+
+		return nil
+	})
 }
 
 func TestWhereNowNoUUIDContext(t *testing.T) {
@@ -69,11 +78,20 @@ func TestWhereNowNoUUIDContext(t *testing.T) {
 
 	pn := pubnub.NewPubNub(config)
 	pn.Subscribe().Channels([]string{"ch1"}).Execute()
-	time.Sleep(2 * time.Second)
-	res, _, err := pn.WhereNowWithContext(backgroundContext).
-		Execute()
+	time.Sleep(1 * time.Millisecond)
 
-	assert.Nil(err)
+	checkFor(assert, 4*time.Second, 500*time.Millisecond, func() error {
+		res, _, err := pn.WhereNowWithContext(backgroundContext).
+			Execute()
 
-	assert.NotEqual(0, len(res.Channels))
+		if err != nil {
+			return err
+		}
+
+		if len(res.Channels) == 0 {
+			return errors.New("res.Channels can't be empty")
+		}
+
+		return nil
+	})
 }

--- a/tests/e2e/where_now_test.go
+++ b/tests/e2e/where_now_test.go
@@ -57,7 +57,7 @@ func TestWhereNowNoUUID(t *testing.T) {
 	pn.Subscribe().Channels([]string{"ch1"}).Execute()
 	time.Sleep(500 * time.Millisecond)
 
-	checkFor(assert, 4*time.Second, 500*time.Millisecond, func() error {
+	checkFor(assert, 5*time.Second, 500*time.Millisecond, func() error {
 		res, _, err := pn.WhereNow().
 			Execute()
 
@@ -78,9 +78,9 @@ func TestWhereNowNoUUIDContext(t *testing.T) {
 
 	pn := pubnub.NewPubNub(config)
 	pn.Subscribe().Channels([]string{"ch1"}).Execute()
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
-	checkFor(assert, 4*time.Second, 500*time.Millisecond, func() error {
+	checkFor(assert, 5*time.Second, 500*time.Millisecond, func() error {
 		res, _, err := pn.WhereNowWithContext(backgroundContext).
 			Execute()
 


### PR DESCRIPTION
fix: Set default limit for object calls with context


fix: Avoid double escaping of some query params

All channel groups management operations could double escape some 
characters which could cause signature problems