### PR TITLE
Avoid double escaping of some query params

### DIFF
--- a/add_channel_channel_group_request.go
+++ b/add_channel_channel_group_request.go
@@ -136,7 +136,7 @@ func (o *addChannelOpts) buildQuery() (*url.Values, error) {
 	var channels []string
 
 	for _, v := range o.Channels {
-		channels = append(channels, utils.URLEncode(v))
+		channels = append(channels, v)
 	}
 
 	q.Set("add", strings.Join(channels, ","))

--- a/add_channels_to_push_request.go
+++ b/add_channels_to_push_request.go
@@ -161,7 +161,7 @@ func (o *addChannelsToPushOpts) buildQuery() (*url.Values, error) {
 	var channels []string
 
 	for _, v := range o.Channels {
-		channels = append(channels, utils.URLEncode(v))
+		channels = append(channels, v)
 	}
 
 	q.Set("add", strings.Join(channels, ","))

--- a/remove_channel_channel_group_request.go
+++ b/remove_channel_channel_group_request.go
@@ -127,7 +127,7 @@ func (o *removeChannelOpts) buildQuery() (*url.Values, error) {
 	var channels []string
 
 	for _, ch := range o.Channels {
-		channels = append(channels, utils.URLEncode(ch))
+		channels = append(channels, ch)
 	}
 
 	q.Set("remove", strings.Join(channels, ","))

--- a/remove_channels_from_push_request.go
+++ b/remove_channels_from_push_request.go
@@ -162,7 +162,7 @@ func (o *removeChannelsFromPushOpts) buildQuery() (*url.Values, error) {
 	var channels []string
 
 	for _, v := range o.Channels {
-		channels = append(channels, utils.URLEncode(v))
+		channels = append(channels, v)
 	}
 
 	q.Set("remove", strings.Join(channels, ","))

--- a/tests/e2e/add_channel_channel_group_test.go
+++ b/tests/e2e/add_channel_channel_group_test.go
@@ -85,6 +85,16 @@ func TestAddChannelToChannelGroupSuperCall(t *testing.T) {
 	assert.Nil(err)
 }
 
+func TestAddChannelWithCharacterToEscape(t *testing.T) {
+	assert := assert.New(t)
+	pn := pubnub.NewPubNub(pamConfigCopy())
+	randomChannel := randomized("ch")
+	randomGroup := randomized("cg")
+
+	_, _, err := pn.AddChannelToChannelGroup().Channels([]string{randomChannel}).ChannelGroup(randomGroup).Execute()
+	assert.NoError(err)
+}
+
 func TestAddChannelToChannelGroupSuccessAdded(t *testing.T) {
 	assert := assert.New(t)
 	pn := pubnub.NewPubNub(configCopy())

--- a/tests/e2e/time_test.go
+++ b/tests/e2e/time_test.go
@@ -1,6 +1,8 @@
 package e2e
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	pubnub "github.com/pubnub/go/v7"
@@ -52,4 +54,75 @@ func TestTimeContext(t *testing.T) {
 	assert.Nil(err)
 
 	assert.True(int64(15059085932399340) < res.Timetoken)
+}
+
+// Message represents the serializable format we use to send a protobuf message over pubnub
+type Message struct {
+	Type string `json:"type" mapstructure:"type"`
+	Data []byte `json:"data" mapstructure:"data"`
+}
+
+type Service struct {
+	pubnubClient *pubnub.PubNub
+}
+
+// CreateMessage will create a serializable message from any proto message
+func CreateMessage() (*Message, error) {
+	bytes := []byte("string to byte array or slice")
+	return &Message{Type: string("This"), Data: bytes}, nil
+}
+
+// SendMessageToChannel will send the given proto message to the specified pubnub channel
+func (s *Service) sendMessageToChannel(ch string) error {
+	message, err := CreateMessage()
+	if err != nil {
+		return fmt.Errorf("error marshalling message: %w", err)
+	}
+	r, _, err := s.pubnubClient.Publish().Channel(ch).Message(message).Serialize(true).UsePost(true).Execute()
+	if err != nil {
+		return fmt.Errorf("error publishing message: %w", err)
+	}
+	println(r.Timestamp)
+	return nil
+}
+
+// SendMessageToChannel will send the given proto message to the specified pubnub channel
+func (s *Service) sendMessageToChannel2(ctx context.Context, ch string) error {
+	message, err := CreateMessage()
+	if err != nil {
+		return fmt.Errorf("error marshalling message: %w", err)
+	}
+	r, _, err := s.pubnubClient.PublishWithContext(ctx).Channel(ch).Message(message).Serialize(true).UsePost(true).Execute()
+	if err != nil {
+		return fmt.Errorf("error publishing message: %w", err)
+	}
+
+	println(r.Timestamp)
+	return nil
+}
+
+func TestWithoutContext(t *testing.T) {
+
+	pn := pubnub.NewPubNub(configCopy())
+
+	service := Service{
+		pubnubClient: pn,
+	}
+
+	err := service.sendMessageToChannel("ch1")
+
+	println(err)
+}
+
+func TestWithContext(t *testing.T) {
+
+	pn := pubnub.NewPubNub(configCopy())
+
+	service := Service{
+		pubnubClient: pn,
+	}
+
+	err := service.sendMessageToChannel2(context.Background(), "ch1")
+
+	println(err)
 }

--- a/tests/e2e/time_test.go
+++ b/tests/e2e/time_test.go
@@ -1,8 +1,6 @@
 package e2e
 
 import (
-	"context"
-	"fmt"
 	"testing"
 
 	pubnub "github.com/pubnub/go/v7"
@@ -54,75 +52,4 @@ func TestTimeContext(t *testing.T) {
 	assert.Nil(err)
 
 	assert.True(int64(15059085932399340) < res.Timetoken)
-}
-
-// Message represents the serializable format we use to send a protobuf message over pubnub
-type Message struct {
-	Type string `json:"type" mapstructure:"type"`
-	Data []byte `json:"data" mapstructure:"data"`
-}
-
-type Service struct {
-	pubnubClient *pubnub.PubNub
-}
-
-// CreateMessage will create a serializable message from any proto message
-func CreateMessage() (*Message, error) {
-	bytes := []byte("string to byte array or slice")
-	return &Message{Type: string("This"), Data: bytes}, nil
-}
-
-// SendMessageToChannel will send the given proto message to the specified pubnub channel
-func (s *Service) sendMessageToChannel(ch string) error {
-	message, err := CreateMessage()
-	if err != nil {
-		return fmt.Errorf("error marshalling message: %w", err)
-	}
-	r, _, err := s.pubnubClient.Publish().Channel(ch).Message(message).Serialize(true).UsePost(true).Execute()
-	if err != nil {
-		return fmt.Errorf("error publishing message: %w", err)
-	}
-	println(r.Timestamp)
-	return nil
-}
-
-// SendMessageToChannel will send the given proto message to the specified pubnub channel
-func (s *Service) sendMessageToChannel2(ctx context.Context, ch string) error {
-	message, err := CreateMessage()
-	if err != nil {
-		return fmt.Errorf("error marshalling message: %w", err)
-	}
-	r, _, err := s.pubnubClient.PublishWithContext(ctx).Channel(ch).Message(message).Serialize(true).UsePost(true).Execute()
-	if err != nil {
-		return fmt.Errorf("error publishing message: %w", err)
-	}
-
-	println(r.Timestamp)
-	return nil
-}
-
-func TestWithoutContext(t *testing.T) {
-
-	pn := pubnub.NewPubNub(configCopy())
-
-	service := Service{
-		pubnubClient: pn,
-	}
-
-	err := service.sendMessageToChannel("ch1")
-
-	println(err)
-}
-
-func TestWithContext(t *testing.T) {
-
-	pn := pubnub.NewPubNub(configCopy())
-
-	service := Service{
-		pubnubClient: pn,
-	}
-
-	err := service.sendMessageToChannel2(context.Background(), "ch1")
-
-	println(err)
 }


### PR DESCRIPTION
It seems that channel list put into query params was double escaped.
First when creating the list value itself and then in SetQueryParam.

This could cause problems with all channel groups management operations
either with wrong signature or with wrong channels being added to channel
group