### PR TITLE
Fix error when destroying client with already closed pn.jobQueue.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-*         @xavrax @marcin-cebo @seba-aln 
+*         @xavrax @marcin-cebo @seba-aln @kgronek-pubnub
 README.md @techwritermat @kazydek @xavrax @marcin-cebo

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,6 +1,11 @@
 ---
-version: v7.3.1
+version: v7.3.2
 changelog:
+  - date: 2025-03-21
+    version: v7.3.2
+    changes:
+      - type: bug
+        text: "Add handling panic while destroying the pubnub client in case pn.jobQueue is already closed. Thanks @piyushkumar96 for your contribution!."
   - date: 2025-03-06
     version: v7.3.1
     changes:
@@ -754,7 +759,7 @@ sdks:
             distribution-type: package
             distribution-repository: GitHub
             package-name: Go
-            location: https://github.com/pubnub/go/releases/tag/v7.3.1
+            location: https://github.com/pubnub/go/releases/tag/v7.3.2
             requires:
               -
                 name: "Go"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v7.3.2
+March 21 2025
+
+#### Fixed
+- Add handling panic while destroying the pubnub client in case pn.jobQueue is already closed. Thanks @piyushkumar96 for your contribution!. Fixed the following issues reported by [@piyushkumar96](https://github.com/piyushkumar96): [#161](https://github.com/pubnub/go/issues/161).
+
 ## v7.3.1
 March 06 2025
 

--- a/pubnub.go
+++ b/pubnub.go
@@ -742,8 +742,22 @@ func (pn *PubNub) Destroy() {
 	pn.Config.Log.Println("calling RemoveAllListeners")
 	pn.subscriptionManager.RemoveAllListeners()
 	pn.Config.Log.Println("after RemoveAllListeners")
-	close(pn.jobQueue)
-	pn.Config.Log.Println("after close jobQueue")
+
+	// Check if jobQueue is already closed before attempting to close it
+	select {
+	case _, ok := <-pn.jobQueue:
+		if !ok {
+			pn.Config.Log.Println("jobQueue is already closed")
+			break
+		}
+		// If the channel is open, proceed to close it
+		close(pn.jobQueue)
+		pn.Config.Log.Println("after close jobQueue")
+	default:
+		// If the channel is closed, no action is needed
+		pn.Config.Log.Println("jobQueue is already closed")
+	}
+
 	pn.requestWorkers.Close()
 	pn.Config.Log.Println("after close requestWorkers")
 	pn.tokenManager.CleanUp()

--- a/pubnub.go
+++ b/pubnub.go
@@ -15,7 +15,7 @@ import (
 // Default constants
 const (
 	// Version :the version of the SDK
-	Version = "7.3.1"
+	Version = "7.3.2"
 	// MaxSequence for publish messages
 	MaxSequence = 65535
 )


### PR DESCRIPTION
fix(pnClient): fix error when destroying client with already closed pn.jobQueue.

Add handling panic while destroying the pubnub client in case pn.jobQueue is already closed. Thanks @piyushkumar96 for your contribution!

Closes #161