### PR TITLE
Add UseRawText parameter to SendFile and PublishFileMessage functions.

### DIFF
--- a/files_common.go
+++ b/files_common.go
@@ -1,7 +1,5 @@
 package pubnub
 
-import "encoding/json"
-
 // PNPublishMessage is the part of the message struct used in Publish File
 type PNPublishMessage struct {
 	Text string `json:"text"`
@@ -10,11 +8,6 @@ type PNPublishMessage struct {
 // PNPublishMessageRaw is used when UseRawText is true - the message is sent as raw text without "text" wrapper
 type PNPublishMessageRaw struct {
 	Text string `json:"-"`
-}
-
-// MarshalJSON customizes JSON marshaling for raw text mode
-func (m PNPublishMessageRaw) MarshalJSON() ([]byte, error) {
-	return json.Marshal(m.Text)
 }
 
 // PNFileInfoForPublish is the part of the message struct used in Publish File

--- a/files_common.go
+++ b/files_common.go
@@ -1,5 +1,7 @@
 package pubnub
 
+import "encoding/json"
+
 // PNPublishMessage is the part of the message struct used in Publish File
 type PNPublishMessage struct {
 	Text string `json:"text"`
@@ -12,7 +14,7 @@ type PNPublishMessageRaw struct {
 
 // MarshalJSON customizes JSON marshaling for raw text mode
 func (m PNPublishMessageRaw) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + m.Text + `"`), nil
+	return json.Marshal(m.Text)
 }
 
 // PNFileInfoForPublish is the part of the message struct used in Publish File
@@ -97,11 +99,10 @@ func ParseFileInfo(filesPayload map[string]interface{}) (PNFileDetails, PNPublis
 	}
 	if m, ok := filesPayload["message"]; ok {
 		if m != nil {
-			// Check if message is a string (raw text format: {"message": "text"})
+			// Handle both raw text format: {"message": "text"} and regular format: {"message": {"text": "text"}}
 			if messageStr, ok := m.(string); ok {
 				resp.PNMessage.Text = messageStr
 			} else if data, ok := m.(map[string]interface{}); ok {
-				// Regular format: {"message": {"text": "text"}}
 				if d, ok := data["text"]; ok {
 					if textStr, ok := d.(string); ok {
 						resp.PNMessage.Text = textStr

--- a/files_common_test.go
+++ b/files_common_test.go
@@ -13,7 +13,7 @@ func TestParseFileInfo(t *testing.T) {
 	resp["file"] = map[string]interface{}{"name": "test_file_upload_name_32899", "id": "9076246e-5036-42af-b3a3-767b514c93c8"}
 	f, m := ParseFileInfo(resp)
 	assert.Equal(f.ID, "9076246e-5036-42af-b3a3-767b514c93c8")
-	assert.Equal(m.Text, "")
+	assert.Nil(m.Text, "Text should be nil when message is nil")
 }
 
 func TestParseFileInfoNotNil(t *testing.T) {
@@ -25,4 +25,192 @@ func TestParseFileInfoNotNil(t *testing.T) {
 	f, m := ParseFileInfo(resp)
 	assert.Equal(f.ID, "9076246e-5036-42af-b3a3-767b514c93c8")
 	assert.Equal(m.Text, "test file")
+}
+
+// TestParseFileInfoWithRawStringMessage tests parsing file info when message is a raw string
+func TestParseFileInfoWithRawStringMessage(t *testing.T) {
+	assert := assert.New(t)
+	resp := make(map[string]interface{})
+	resp["message"] = "raw message"
+	resp["file"] = map[string]interface{}{"name": "test_file.txt", "id": "file-id-123"}
+
+	f, m := ParseFileInfo(resp)
+	assert.Equal("file-id-123", f.ID)
+	assert.Equal("test_file.txt", f.Name)
+	assert.Equal("raw message", m.Text)
+}
+
+// TestParseFileInfoWithJSONObjectMessage tests parsing when message is a JSON object
+func TestParseFileInfoWithJSONObjectMessage(t *testing.T) {
+	assert := assert.New(t)
+	resp := make(map[string]interface{})
+	resp["message"] = map[string]interface{}{
+		"type":     "document",
+		"priority": "high",
+		"metadata": map[string]interface{}{
+			"author": "John Doe",
+			"tags":   []string{"important", "quarterly"},
+		},
+	}
+	resp["file"] = map[string]interface{}{"name": "document.pdf", "id": "file-id-456"}
+
+	f, m := ParseFileInfo(resp)
+	assert.Equal("file-id-456", f.ID)
+	assert.Equal("document.pdf", f.Name)
+
+	// Verify the message is correctly parsed as a map
+	messageMap, ok := m.Text.(map[string]interface{})
+	assert.True(ok, "Message should be a map[string]interface{}")
+	assert.Equal("document", messageMap["type"])
+	assert.Equal("high", messageMap["priority"])
+
+	metadata, ok := messageMap["metadata"].(map[string]interface{})
+	assert.True(ok)
+	assert.Equal("John Doe", metadata["author"])
+}
+
+// TestParseFileInfoWithJSONObjectTextWrapper tests parsing when message has "text" wrapper with JSON object
+func TestParseFileInfoWithJSONObjectTextWrapper(t *testing.T) {
+	assert := assert.New(t)
+	resp := make(map[string]interface{})
+	resp["message"] = map[string]interface{}{
+		"text": map[string]interface{}{
+			"user_id": float64(123), // Use float64 to simulate JSON unmarshaling behavior
+			"action":  "upload",
+		},
+	}
+	resp["file"] = map[string]interface{}{"name": "image.jpg", "id": "file-id-789"}
+
+	f, m := ParseFileInfo(resp)
+	assert.Equal("file-id-789", f.ID)
+	assert.Equal("image.jpg", f.Name)
+
+	// Verify the message is correctly extracted from "text" wrapper
+	messageMap, ok := m.Text.(map[string]interface{})
+	assert.True(ok, "Message should be a map[string]interface{}")
+
+	// JSON unmarshaling converts numbers to float64
+	userID, ok := messageMap["user_id"].(float64)
+	assert.True(ok, "user_id should be float64")
+	assert.Equal(float64(123), userID)
+	assert.Equal("upload", messageMap["action"])
+}
+
+// TestParseFileInfoWithArrayMessage tests parsing when message is an array
+func TestParseFileInfoWithArrayMessage(t *testing.T) {
+	assert := assert.New(t)
+	resp := make(map[string]interface{})
+	resp["message"] = []interface{}{"item1", "item2", "item3"}
+	resp["file"] = map[string]interface{}{"name": "list.txt", "id": "file-id-999"}
+
+	f, m := ParseFileInfo(resp)
+	assert.Equal("file-id-999", f.ID)
+	assert.Equal("list.txt", f.Name)
+
+	// Verify the message is correctly parsed as an array
+	messageArray, ok := m.Text.([]interface{})
+	assert.True(ok, "Message should be a []interface{}")
+	assert.Equal(3, len(messageArray))
+	assert.Equal("item1", messageArray[0])
+	assert.Equal("item2", messageArray[1])
+	assert.Equal("item3", messageArray[2])
+}
+
+// TestParseFileInfoWithNumericMessage tests parsing when message is a number
+func TestParseFileInfoWithNumericMessage(t *testing.T) {
+	assert := assert.New(t)
+	resp := make(map[string]interface{})
+	resp["message"] = float64(42)
+	resp["file"] = map[string]interface{}{"name": "number.txt", "id": "file-id-111"}
+
+	f, m := ParseFileInfo(resp)
+	assert.Equal("file-id-111", f.ID)
+	assert.Equal("number.txt", f.Name)
+
+	// Verify the message is correctly parsed as a number
+	messageNumber, ok := m.Text.(float64)
+	assert.True(ok, "Message should be a float64")
+	assert.Equal(float64(42), messageNumber)
+}
+
+// TestParseFileInfoWithBooleanMessage tests parsing when message is a boolean
+func TestParseFileInfoWithBooleanMessage(t *testing.T) {
+	assert := assert.New(t)
+	resp := make(map[string]interface{})
+	resp["message"] = true
+	resp["file"] = map[string]interface{}{"name": "bool.txt", "id": "file-id-222"}
+
+	f, m := ParseFileInfo(resp)
+	assert.Equal("file-id-222", f.ID)
+	assert.Equal("bool.txt", f.Name)
+
+	// Verify the message is correctly parsed as a boolean
+	messageBool, ok := m.Text.(bool)
+	assert.True(ok, "Message should be a bool")
+	assert.Equal(true, messageBool)
+}
+
+// TestParseFileInfoWithEmptyMap tests parsing when message is an empty JSON object
+func TestParseFileInfoWithEmptyMap(t *testing.T) {
+	assert := assert.New(t)
+	resp := make(map[string]interface{})
+	resp["message"] = map[string]interface{}{} // Empty map
+	resp["file"] = map[string]interface{}{"name": "empty.json", "id": "file-id-444"}
+
+	f, m := ParseFileInfo(resp)
+	assert.Equal("file-id-444", f.ID)
+	assert.Equal("empty.json", f.Name)
+
+	// Empty map without "text" field should be treated as raw format (entire empty object)
+	messageMap, ok := m.Text.(map[string]interface{})
+	assert.True(ok, "Message should be a map[string]interface{}")
+	assert.Equal(0, len(messageMap), "Empty map should be preserved")
+}
+
+// TestParseFileInfoWithComplexNestedMessage tests parsing with deeply nested structures
+func TestParseFileInfoWithComplexNestedMessage(t *testing.T) {
+	assert := assert.New(t)
+	resp := make(map[string]interface{})
+	resp["message"] = map[string]interface{}{
+		"user": map[string]interface{}{
+			"id":   123,
+			"name": "Test User",
+			"settings": map[string]interface{}{
+				"theme":         "dark",
+				"notifications": true,
+			},
+		},
+		"file_info": map[string]interface{}{
+			"uploaded_at": "2023-01-01T00:00:00Z",
+			"size":        1024,
+			"tags":        []interface{}{"important", "document"},
+		},
+	}
+	resp["file"] = map[string]interface{}{"name": "complex.json", "id": "file-id-333"}
+
+	f, m := ParseFileInfo(resp)
+	assert.Equal("file-id-333", f.ID)
+	assert.Equal("complex.json", f.Name)
+
+	// Verify the complex nested structure is preserved
+	messageMap, ok := m.Text.(map[string]interface{})
+	assert.True(ok, "Message should be a map[string]interface{}")
+
+	user, ok := messageMap["user"].(map[string]interface{})
+	assert.True(ok)
+	assert.Equal("Test User", user["name"])
+
+	settings, ok := user["settings"].(map[string]interface{})
+	assert.True(ok)
+	assert.Equal("dark", settings["theme"])
+	assert.Equal(true, settings["notifications"])
+
+	fileInfo, ok := messageMap["file_info"].(map[string]interface{})
+	assert.True(ok)
+
+	tags, ok := fileInfo["tags"].([]interface{})
+	assert.True(ok)
+	assert.Equal(2, len(tags))
+	assert.Equal("important", tags[0])
+	assert.Equal("document", tags[1])
 }

--- a/files_send_file.go
+++ b/files_send_file.go
@@ -288,11 +288,7 @@ func newPNSendFileResponse(jsonBytes []byte, o *sendFileOpts,
 	maxCount := o.config().FileMessagePublishRetryLimit
 	for !sent && tryCount < maxCount {
 		tryCount++
-		var pubFileMessageResponse *PublishFileMessageResponse
-		var pubFileResponseStatus StatusResponse
-		var errPubFileResponse error
-
-		pubFileMessageResponse, pubFileResponseStatus, errPubFileResponse = o.pubnub.PublishFileMessage().TTL(o.TTL).Meta(o.Meta).ShouldStore(o.ShouldStore).Channel(o.Channel).Message(message).UseRawText(o.UseRawText).Execute()
+		pubFileMessageResponse, pubFileResponseStatus, errPubFileResponse := o.pubnub.PublishFileMessage().TTL(o.TTL).Meta(o.Meta).ShouldStore(o.ShouldStore).Channel(o.Channel).Message(message).UseRawText(o.UseRawText).Execute()
 		if errPubFileResponse != nil {
 			if tryCount >= maxCount {
 				pubFileResponseStatus.AdditionalData = file

--- a/files_send_file.go
+++ b/files_send_file.go
@@ -109,6 +109,10 @@ func (b *sendFileBuilder) CustomMessageType(messageType string) *sendFileBuilder
 // UseRawText sets whether the message text should be sent as raw text instead of being wrapped in a JSON "text" field.
 // When true, the message will be sent directly without the {"text": "message"} wrapper.
 // Defaults to false for backward compatibility.
+// Example:
+//
+//	UseRawText(false): {"message": {"text": "Hello"}, "file": {"id": "123", "name": "file.txt"}}
+//	UseRawText(true):  {"message": "Hello", "file": {"id": "123", "name": "file.txt"}}
 func (b *sendFileBuilder) UseRawText(useRawText bool) *sendFileBuilder {
 	b.opts.UseRawText = useRawText
 

--- a/files_send_file_test.go
+++ b/files_send_file_test.go
@@ -839,7 +839,7 @@ func TestSendFileBuilderDefaults(t *testing.T) {
 
 	assert.Equal("", builder.opts.Channel)
 	assert.Equal("", builder.opts.Name)
-	assert.Equal("", builder.opts.Message)
+	assert.Nil(builder.opts.Message)
 	assert.Nil(builder.opts.File)
 	assert.Equal("", builder.opts.CipherKey)
 	assert.Equal(0, builder.opts.TTL)
@@ -911,48 +911,48 @@ func TestSendFileIsCustomMessageTypeCorrect(t *testing.T) {
 }
 
 // ===========================
-// UseRawText Tests
+// UseRawMessage Tests
 // ===========================
 
-func TestSendFileBuilderUseRawText(t *testing.T) {
+func TestSendFileBuilderUseRawMessage(t *testing.T) {
 	assert := assert.New(t)
 	pubnub := NewPubNub(NewDemoConfig())
 	builder := newSendFileBuilder(pubnub)
 
-	// Test UseRawText true
-	result := builder.UseRawText(true)
-	assert.True(builder.opts.UseRawText)
+	// Test UseRawMessage true
+	result := builder.UseRawMessage(true)
+	assert.True(builder.opts.UseRawMessage)
 	assert.Equal(builder, result) // Fluent interface
 
-	// Test UseRawText false
-	result = builder.UseRawText(false)
-	assert.False(builder.opts.UseRawText)
+	// Test UseRawMessage false
+	result = builder.UseRawMessage(false)
+	assert.False(builder.opts.UseRawMessage)
 	assert.Equal(builder, result) // Fluent interface
 }
 
-func TestSendFileUseRawTextDefaults(t *testing.T) {
+func TestSendFileUseRawMessageDefaults(t *testing.T) {
 	assert := assert.New(t)
 	pubnub := NewPubNub(NewDemoConfig())
 	opts := newSendFileOpts(pubnub, pubnub.ctx)
 
 	// Test default value
-	assert.False(opts.UseRawText)
+	assert.False(opts.UseRawMessage)
 }
 
-func TestSendFileUseRawTextMethodChaining(t *testing.T) {
+func TestSendFileUseRawMessageMethodChaining(t *testing.T) {
 	assert := assert.New(t)
 	pubnub := NewPubNub(NewDemoConfig())
 	builder := newSendFileBuilder(pubnub)
 	tempFile, _ := os.CreateTemp("", "test")
 	defer os.Remove(tempFile.Name())
 
-	// Test method chaining with UseRawText
+	// Test method chaining with UseRawMessage
 	result := builder.
 		Channel("test-channel").
 		Name("test.txt").
 		Message("test message").
 		File(tempFile).
-		UseRawText(true).
+		UseRawMessage(true).
 		ShouldStore(true).
 		TTL(24)
 
@@ -960,20 +960,20 @@ func TestSendFileUseRawTextMethodChaining(t *testing.T) {
 	assert.Equal("test.txt", builder.opts.Name)
 	assert.Equal("test message", builder.opts.Message)
 	assert.Equal(tempFile, builder.opts.File)
-	assert.True(builder.opts.UseRawText)
+	assert.True(builder.opts.UseRawMessage)
 	assert.True(builder.opts.ShouldStore)
 	assert.Equal(24, builder.opts.TTL)
 	assert.Equal(builder, result) // Fluent interface
 }
 
-func TestSendFileUseRawTextWithAllParameters(t *testing.T) {
+func TestSendFileUseRawMessageWithAllParameters(t *testing.T) {
 	assert := assert.New(t)
 	pubnub := NewPubNub(NewDemoConfig())
 	builder := newSendFileBuilder(pubnub)
 	tempFile, _ := os.CreateTemp("", "test")
 	defer os.Remove(tempFile.Name())
 
-	// Test UseRawText with all other parameters
+	// Test UseRawMessage with all other parameters
 	queryParam := map[string]string{"param1": "value1"}
 	meta := map[string]interface{}{"key": "value"}
 
@@ -988,7 +988,7 @@ func TestSendFileUseRawTextWithAllParameters(t *testing.T) {
 		ShouldStore(true).
 		CustomMessageType("custom-type").
 		QueryParam(queryParam).
-		UseRawText(true).
+		UseRawMessage(true).
 		Transport(&http.Transport{})
 
 	// Verify all parameters are set correctly
@@ -1002,7 +1002,7 @@ func TestSendFileUseRawTextWithAllParameters(t *testing.T) {
 	assert.True(builder.opts.ShouldStore)
 	assert.Equal("custom-type", builder.opts.CustomMessageType)
 	assert.Equal(queryParam, builder.opts.QueryParam)
-	assert.True(builder.opts.UseRawText)
+	assert.True(builder.opts.UseRawMessage)
 	assert.NotNil(builder.opts.Transport)
 	assert.Equal(builder, result) // Fluent interface
 }

--- a/files_send_file_to_s3.go
+++ b/files_send_file_to_s3.go
@@ -103,7 +103,6 @@ func (o *sendFileToS3Opts) buildQuery() (*url.Values, error) {
 }
 
 func (o *sendFileToS3Opts) buildBodyMultipartFileUpload() (bytes.Buffer, *multipart.Writer, int64, error) {
-	// Check if file is nil
 	if o.File == nil {
 		return bytes.Buffer{}, nil, 0, fmt.Errorf("file is nil")
 	}

--- a/files_send_file_to_s3.go
+++ b/files_send_file_to_s3.go
@@ -3,6 +3,7 @@ package pubnub
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -102,11 +103,18 @@ func (o *sendFileToS3Opts) buildQuery() (*url.Values, error) {
 }
 
 func (o *sendFileToS3Opts) buildBodyMultipartFileUpload() (bytes.Buffer, *multipart.Writer, int64, error) {
+	// Check if file is nil
+	if o.File == nil {
+		return bytes.Buffer{}, nil, 0, fmt.Errorf("file is nil")
+	}
 
-	fileInfo, _ := o.File.Stat()
+	fileInfo, err := o.File.Stat()
+	if err != nil {
+		return bytes.Buffer{}, nil, 0, fmt.Errorf("failed to get file info: %v", err)
+	}
 	s := fileInfo.Size()
 	buffer := make([]byte, 512)
-	_, err := o.File.Read(buffer)
+	_, err = o.File.Read(buffer)
 	if err != nil {
 		return bytes.Buffer{}, nil, s, err
 	}

--- a/publish_file_message.go
+++ b/publish_file_message.go
@@ -232,12 +232,11 @@ func (o *publishFileMessageOpts) buildPath() (string, error) {
 			Name: o.FileName,
 		}
 
-		m := &PNPublishMessage{
-			Text: o.MessageText,
-		}
 		o.Message = PNPublishFileMessage{
-			PNFile:    file,
-			PNMessage: m,
+			PNFile: file,
+			PNMessage: &PNPublishMessage{
+				Text: o.MessageText,
+			},
 		}
 	}
 

--- a/publish_file_message.go
+++ b/publish_file_message.go
@@ -214,7 +214,23 @@ func (o *publishFileMessageOpts) buildRawTextMessage() interface{} {
 			},
 		}
 	}
-	return o.MessageText
+	if filesPayloadRaw, ok := o.Message.(PNPublishFileMessageRaw); ok && filesPayloadRaw.PNMessage != nil {
+		return map[string]interface{}{
+			"message": filesPayloadRaw.PNMessage.Text,
+			"file": map[string]interface{}{
+				"id":   filesPayloadRaw.PNFile.ID,
+				"name": filesPayloadRaw.PNFile.Name,
+			},
+		}
+	}
+	// Fallback: construct message from individual fields (MessageText, FileID, FileName)
+	return map[string]interface{}{
+		"message": o.MessageText,
+		"file": map[string]interface{}{
+			"id":   o.FileID,
+			"name": o.FileName,
+		},
+	}
 }
 
 func (o *publishFileMessageOpts) buildPath() (string, error) {

--- a/publish_file_message_test.go
+++ b/publish_file_message_test.go
@@ -684,46 +684,46 @@ func TestPublishFileMessageWithComplexMeta(t *testing.T) {
 }
 
 // ===========================
-// UseRawText Tests
+// UseRawMessage Tests
 // ===========================
 
-func TestPublishFileMessageBuilderUseRawText(t *testing.T) {
+func TestPublishFileMessageBuilderUseRawMessage(t *testing.T) {
 	assert := assert.New(t)
 	pubnub := NewPubNub(NewDemoConfig())
 	builder := newPublishFileMessageBuilder(pubnub)
 
-	// Test UseRawText true
-	result := builder.UseRawText(true)
-	assert.True(builder.opts.UseRawText)
+	// Test UseRawMessage true
+	result := builder.UseRawMessage(true)
+	assert.True(builder.opts.UseRawMessage)
 	assert.Equal(builder, result) // Fluent interface
 
-	// Test UseRawText false
-	result = builder.UseRawText(false)
-	assert.False(builder.opts.UseRawText)
+	// Test UseRawMessage false
+	result = builder.UseRawMessage(false)
+	assert.False(builder.opts.UseRawMessage)
 	assert.Equal(builder, result) // Fluent interface
 }
 
-func TestPublishFileMessageUseRawTextDefaults(t *testing.T) {
+func TestPublishFileMessageUseRawMessageDefaults(t *testing.T) {
 	assert := assert.New(t)
 	pubnub := NewPubNub(NewDemoConfig())
 	opts := newPublishFileMessageOpts(pubnub, pubnub.ctx)
 
 	// Test default value
-	assert.False(opts.UseRawText)
+	assert.False(opts.UseRawMessage)
 }
 
-func TestPublishFileMessageUseRawTextMethodChaining(t *testing.T) {
+func TestPublishFileMessageUseRawMessageMethodChaining(t *testing.T) {
 	assert := assert.New(t)
 	pubnub := NewPubNub(NewDemoConfig())
 	builder := newPublishFileMessageBuilder(pubnub)
 
-	// Test method chaining with UseRawText
+	// Test method chaining with UseRawMessage
 	result := builder.
 		Channel("test-channel").
 		FileID("test-id").
 		FileName("test.txt").
 		MessageText("test message").
-		UseRawText(true).
+		UseRawMessage(true).
 		ShouldStore(true).
 		TTL(24)
 
@@ -731,18 +731,18 @@ func TestPublishFileMessageUseRawTextMethodChaining(t *testing.T) {
 	assert.Equal("test-id", builder.opts.FileID)
 	assert.Equal("test.txt", builder.opts.FileName)
 	assert.Equal("test message", builder.opts.MessageText)
-	assert.True(builder.opts.UseRawText)
+	assert.True(builder.opts.UseRawMessage)
 	assert.True(builder.opts.ShouldStore)
 	assert.Equal(24, builder.opts.TTL)
 	assert.Equal(builder, result) // Fluent interface
 }
 
-func TestPublishFileMessageUseRawTextWithAllParameters(t *testing.T) {
+func TestPublishFileMessageUseRawMessageWithAllParameters(t *testing.T) {
 	assert := assert.New(t)
 	pubnub := NewPubNub(NewDemoConfig())
 	builder := newPublishFileMessageBuilder(pubnub)
 
-	// Test UseRawText with all other parameters
+	// Test UseRawMessage with all other parameters
 	queryParam := map[string]string{"param1": "value1"}
 	meta := map[string]interface{}{"key": "value"}
 
@@ -755,7 +755,7 @@ func TestPublishFileMessageUseRawTextWithAllParameters(t *testing.T) {
 		Meta(meta).
 		ShouldStore(true).
 		QueryParam(queryParam).
-		UseRawText(true).
+		UseRawMessage(true).
 		Transport(&http.Transport{})
 
 	// Verify all parameters are set correctly
@@ -767,12 +767,12 @@ func TestPublishFileMessageUseRawTextWithAllParameters(t *testing.T) {
 	assert.Equal(meta, builder.opts.Meta)
 	assert.True(builder.opts.ShouldStore)
 	assert.Equal(queryParam, builder.opts.QueryParam)
-	assert.True(builder.opts.UseRawText)
+	assert.True(builder.opts.UseRawMessage)
 	assert.NotNil(builder.opts.Transport)
 	assert.Equal(builder, result) // Fluent interface
 }
 
-func TestPublishFileMessageBuildRawTextMessage(t *testing.T) {
+func TestPublishFileMessageBuildRawMessage(t *testing.T) {
 	assert := assert.New(t)
 	pubnub := NewPubNub(NewDemoConfig())
 	opts := newPublishFileMessageOpts(pubnub, pubnub.ctx)
@@ -790,7 +790,7 @@ func TestPublishFileMessageBuildRawTextMessage(t *testing.T) {
 		PNMessage: message,
 	}
 
-	result := opts.buildRawTextMessage()
+	result := opts.buildRawMessage()
 	rawMessage, ok := result.(map[string]interface{})
 	assert.True(ok)
 	assert.Equal("Hello World", rawMessage["message"])
@@ -813,7 +813,7 @@ func TestPublishFileMessageBuildRawTextMessage(t *testing.T) {
 		PNMessage: messageRaw,
 	}
 
-	result = opts.buildRawTextMessage()
+	result = opts.buildRawMessage()
 	rawMessage, ok = result.(map[string]interface{})
 	assert.True(ok)
 	assert.Equal("Raw Message", rawMessage["message"])
@@ -828,7 +828,7 @@ func TestPublishFileMessageBuildRawTextMessage(t *testing.T) {
 	opts.MessageText = "Fallback message"
 	opts.FileID = "fallback-id"
 	opts.FileName = "fallback.txt"
-	result = opts.buildRawTextMessage()
+	result = opts.buildRawMessage()
 	rawMessage, ok = result.(map[string]interface{})
 	assert.True(ok, "Fallback should return map[string]interface{}")
 	assert.Equal("Fallback message", rawMessage["message"])
@@ -839,28 +839,28 @@ func TestPublishFileMessageBuildRawTextMessage(t *testing.T) {
 	assert.Equal("fallback.txt", fileInfo["name"])
 }
 
-// TestPublishFileMessageBuildRawTextMessageWithIndividualFields tests the complete message structure
-// when using individual field setters (MessageText, FileID, FileName) with UseRawText
-func TestPublishFileMessageBuildRawTextMessageWithIndividualFields(t *testing.T) {
+// TestPublishFileMessageBuildRawMessageWithIndividualFields tests the complete message structure
+// when using individual field setters (MessageText, FileID, FileName) with UseRawMessage
+func TestPublishFileMessageBuildRawMessageWithIndividualFields(t *testing.T) {
 	assert := assert.New(t)
 	pubnub := NewPubNub(NewDemoConfig())
 	builder := newPublishFileMessageBuilder(pubnub)
 
-	// Test using individual field setters with UseRawText(true)
+	// Test using individual field setters with UseRawMessage(true)
 	builder.
 		Channel("test-channel").
 		MessageText("Test message").
 		FileID("test-id").
 		FileName("test.txt").
-		UseRawText(true)
+		UseRawMessage(true)
 
-	// Build the path which internally calls buildRawTextMessage
+	// Build the path which internally calls buildRawMessage
 	path, err := builder.opts.buildPath()
 	assert.Nil(err)
 	assert.NotEmpty(path)
 
 	// Verify the message structure
-	result := builder.opts.buildRawTextMessage()
+	result := builder.opts.buildRawMessage()
 	rawMessage, ok := result.(map[string]interface{})
 	assert.True(ok, "Should return map[string]interface{} when using individual fields")
 	assert.Equal("Test message", rawMessage["message"], "Message text should be present")
@@ -871,9 +871,9 @@ func TestPublishFileMessageBuildRawTextMessageWithIndividualFields(t *testing.T)
 	assert.Equal("test.txt", fileInfo["name"], "File name should be present")
 }
 
-// TestPublishFileMessageUseRawTextWithIndividualFieldsViaPath tests the full path generation
-// when using individual field setters with UseRawText to ensure the message is properly encoded
-func TestPublishFileMessageUseRawTextWithIndividualFieldsViaPath(t *testing.T) {
+// TestPublishFileMessageUseRawMessageWithIndividualFieldsViaPath tests the full path generation
+// when using individual field setters with UseRawMessage to ensure the message is properly encoded
+func TestPublishFileMessageUseRawMessageWithIndividualFieldsViaPath(t *testing.T) {
 	assert := assert.New(t)
 	pubnub := NewPubNub(NewDemoConfig())
 	builder := newPublishFileMessageBuilder(pubnub)
@@ -884,13 +884,13 @@ func TestPublishFileMessageUseRawTextWithIndividualFieldsViaPath(t *testing.T) {
 		MessageText("Hello World").
 		FileID("file-123").
 		FileName("document.pdf").
-		UseRawText(true)
+		UseRawMessage(true)
 
 	path, err := builder.opts.buildPath()
 	assert.Nil(err)
 	assert.NotEmpty(path)
 
-	// The path should contain the URL-encoded JSON with raw text format
+	// The path should contain the URL-encoded JSON with raw message format
 	// Expected structure: {"message":"Hello World","file":{"id":"file-123","name":"document.pdf"}}
 	assert.Contains(path, "test-channel", "Path should contain channel name")
 	// The message should be in the path as URL-encoded JSON

--- a/tests/e2e/files_test.go
+++ b/tests/e2e/files_test.go
@@ -291,10 +291,6 @@ func FileUploadCommon(t *testing.T, useCipher bool, customCipher string, filepat
 	_, statusDelFile, errDelFile := pn.DeleteFile().Channel(ch).ID(id).Name(name).Execute()
 	assert.Nil(errDelFile)
 	assert.Equal(200, statusDelFile.StatusCode)
-
-	// _, statusGetFile2, _ := pn.DownloadFile().Channel(ch).ID(id).Name(name).Execute()
-	// assert.Equal(404, statusGetFile2.StatusCode)
-
 }
 
 func FileUploadCommonWithUseRawText(t *testing.T, useCipher bool, customCipher string, filepathInput, filepathOutput string) {
@@ -535,10 +531,6 @@ func FileUploadCommonWithUseRawText(t *testing.T, useCipher bool, customCipher s
 	_, statusDelFile, errDelFile := pn.DeleteFile().Channel(ch).ID(id).Name(name).Execute()
 	assert.Nil(errDelFile)
 	assert.Equal(200, statusDelFile.StatusCode)
-
-	// _, statusGetFile2, _ := pn.DownloadFile().Channel(ch).ID(id).Name(name).Execute()
-	// assert.Equal(404, statusGetFile2.StatusCode)
-
 }
 
 func unpadPKCS7(data []byte) ([]byte, error) {

--- a/tests/e2e/files_test.go
+++ b/tests/e2e/files_test.go
@@ -57,7 +57,8 @@ func TestFileUploadWithUseRawMessageAndCipher(t *testing.T) {
 }
 
 type FileData struct {
-	id, url, name, message string
+	id, url, name string
+	message       interface{}
 }
 
 func FileUploadCommon(t *testing.T, useCipher bool, customCipher string, filepathInput, filepathOutput string) {
@@ -114,7 +115,7 @@ func FileUploadCommon(t *testing.T, useCipher bool, customCipher string, filepat
 
 					fmt.Println(" --- File: ")
 					fmt.Printf("%v\n", file)
-					fmt.Printf("file.File.PNMessage.Text: %s\n", file.File.PNMessage.Text)
+					fmt.Printf("file.File.PNMessage.Text: %v\n", file.File.PNMessage.Text)
 					fmt.Printf("file.File.PNFile.Name: %s\n", file.File.PNFile.Name)
 					fmt.Printf("file.File.PNFile.ID: %s\n", file.File.PNFile.ID)
 					fmt.Printf("file.File.PNFile.URL: %s\n", file.File.PNFile.URL)
@@ -347,7 +348,7 @@ func FileUploadCommonWithUseRawMessage(t *testing.T, useCipher bool, customCiphe
 
 					fmt.Println(" --- File: ")
 					fmt.Printf("%v\n", file)
-					fmt.Printf("file.File.PNMessage.Text: %s\n", file.File.PNMessage.Text)
+					fmt.Printf("file.File.PNMessage.Text: %v\n", file.File.PNMessage.Text)
 					fmt.Printf("file.File.PNFile.Name: %s\n", file.File.PNFile.Name)
 					fmt.Printf("file.File.PNFile.ID: %s\n", file.File.PNFile.ID)
 					fmt.Printf("file.File.PNFile.URL: %s\n", file.File.PNFile.URL)

--- a/tests/e2e/files_test.go
+++ b/tests/e2e/files_test.go
@@ -48,12 +48,12 @@ func TestFileUploadWithCustomCipher(t *testing.T) {
 	FileUploadCommon(t, true, "enigma2", "file_upload_test.txt", "file_upload_test_output.txt")
 }
 
-func TestFileUploadWithUseRawText(t *testing.T) {
-	FileUploadCommonWithUseRawText(t, false, "", "file_upload_test.txt", "file_upload_test_output.txt")
+func TestFileUploadWithUseRawMessage(t *testing.T) {
+	FileUploadCommonWithUseRawMessage(t, false, "", "file_upload_test.txt", "file_upload_test_output.txt")
 }
 
-func TestFileUploadWithUseRawTextAndCipher(t *testing.T) {
-	FileUploadCommonWithUseRawText(t, true, "", "file_upload_test.txt", "file_upload_test_output.txt")
+func TestFileUploadWithUseRawMessageAndCipher(t *testing.T) {
+	FileUploadCommonWithUseRawMessage(t, true, "", "file_upload_test.txt", "file_upload_test_output.txt")
 }
 
 type FileData struct {
@@ -293,7 +293,7 @@ func FileUploadCommon(t *testing.T, useCipher bool, customCipher string, filepat
 	assert.Equal(200, statusDelFile.StatusCode)
 }
 
-func FileUploadCommonWithUseRawText(t *testing.T, useCipher bool, customCipher string, filepathInput, filepathOutput string) {
+func FileUploadCommonWithUseRawMessage(t *testing.T, useCipher bool, customCipher string, filepathInput, filepathOutput string) {
 	assert := assert.New(t)
 
 	pn := pubnub.NewPubNub(pamConfigCopy())
@@ -371,8 +371,8 @@ func FileUploadCommonWithUseRawText(t *testing.T, useCipher bool, customCipher s
 	// Sleep a bit, to give client some time to subscribe on channels firs.
 	time.Sleep(100 * time.Millisecond)
 
-	// Test with UseRawText(true) - message should be sent as raw text without "text" wrapper
-	resSendFile, statusSendFile, _ := pn.SendFile().Channel(ch).Message(message).CipherKey(cipherKey).Name(name).File(file).ShouldStore(true).UseRawText(true).Execute()
+	// Test with UseRawMessage(true) - message should be sent as raw content without "text" wrapper
+	resSendFile, statusSendFile, _ := pn.SendFile().Channel(ch).Message(message).CipherKey(cipherKey).Name(name).File(file).ShouldStore(true).UseRawMessage(true).Execute()
 	assert.Equal(200, statusSendFile.StatusCode)
 	if enableDebuggingInTests {
 		fmt.Println("statusSendFile.AdditionalData:", statusSendFile.AdditionalData)
@@ -472,7 +472,7 @@ func FileUploadCommonWithUseRawText(t *testing.T, useCipher bool, customCipher s
 			Execute()
 		chMessages := ret1.Messages[ch]
 		bFoundInFetch := false
-		// With UseRawText(true), the message structure should be different - raw text instead of {"text": "message"}
+		// With UseRawMessage(true), the message structure should be different - raw message instead of {"text": "message"}
 		for i := 0; i < len(chMessages); i++ {
 
 			m := chMessages[i].Message
@@ -481,19 +481,19 @@ func FileUploadCommonWithUseRawText(t *testing.T, useCipher bool, customCipher s
 				fmt.Println("pubnub.PNFileDetails", file.ID)
 				fmt.Println("pubnub.PNFileDetails", file.Name)
 			}
-			// With UseRawText(true), the message should be a string directly, not wrapped in PNPublishMessage
+			// With UseRawMessage(true), the message should be a string directly, not wrapped in PNPublishMessage
 			if msg, ok := m.(string); ok {
 				if enableDebuggingInTests {
-					fmt.Println("Raw text message:", msg)
+					fmt.Println("Raw message:", msg)
 				}
 				if msg == message && file.ID == id && file.Name == name && chMessages[i].MessageType == 4 && chMessages[i].UUID == pn.Config.UUID {
 					bFoundInFetch = true
 					break
 				}
 			} else if msg, ok := m.(pubnub.PNPublishMessage); ok {
-				// Fallback to check if it's still wrapped (shouldn't happen with UseRawText=true)
+				// Fallback to check if it's still wrapped (shouldn't happen with UseRawMessage=true)
 				if enableDebuggingInTests {
-					fmt.Println("Wrapped message (unexpected with UseRawText=true):", msg.Text)
+					fmt.Println("Wrapped message (unexpected with UseRawMessage=true):", msg.Text)
 				}
 				if msg.Text == message && file.ID == id && file.Name == name && chMessages[i].MessageType == 4 && chMessages[i].UUID == pn.Config.UUID {
 					bFoundInFetch = true


### PR DESCRIPTION
add(files): Add `UseRawMessage` parameter to `SendFile` and `PublishFileMessage` functions.

Add `UseRawMessage` parameter to `SendFile` and `PublishFileMessage` functions - when used message won't be wrapped in "text" Json field.

improve(files): Change `PNPublishMessage.Text` parameter to be interface instead of string.

Change `PNPublishMessage.Text` parameter to be interface instead of string - this enables sending other Json types. **BREAKING CHANGE**