### PR TITLE
Create new logger manager for advanced logging.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-*         @kgronek-pubnub @xavrax @marcin-cebo
+*         @kgronek-pubnub @jakub-grzesiowski @xavrax @marcin-cebo
 README.md @techwritermat @kazydek @xavrax @marcin-cebo

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,10 +21,6 @@ jobs:
     name: Integration and Unit tests
     runs-on:
       group: organization/Default
-    strategy:
-      fail-fast: true
-      matrix:
-        go: [1.18.9, 1.19.4]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -37,16 +33,16 @@ jobs:
           ref: v1
           token: ${{ secrets.GH_TOKEN }}
           path: .github/.release/actions
-      - name: Setup Go ${{ matrix.go }}
+      - name: Setup Go 1.19.4
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
+          go-version: 1.19.4
           cache: true
       - name: Install gotestsum
         run: |
           go install gotest.tools/gotestsum@v1.12.0
           gotestsum --version
-      - name: Build and run tests for Go ${{ matrix.go }}
+      - name: Build and run tests
         run: bash ./scripts/run-tests-gotestsum.sh -mod=mod testname
         timeout-minutes: 15
       - name: Cancel workflow runs for commit on error

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,6 +1,15 @@
 ---
-version: v8.0.0
+version: v8.1.0
 changelog:
+  - date: 2025-11-17
+    version: v8.1.0
+    changes:
+      - type: feature
+        text: "Add new logging system with `LoggerManager` supporting multiple custom loggers, structured log message types (network requests/responses, errors, user inputs), and PNLogger interface. Includes `DefaultLogger` with configurable log levels and detailed SDK operation logging. The new Config.Loggers field replaces deprecated Config.Log while maintaining backward compatibility."
+      - type: improvement
+        text: "Refactor logs across the whole SDK. Now logs have dedicated structure and type, so only intended type will be printed. There is now much more logs, especially in internal systems."
+      - type: improvement
+        text: "Deprecate the old Logger. The old logger is still working (for backward compatibility) and is default to `PNLogLevelDebug`."
   - date: 2025-10-29
     version: v8.0.0
     changes:
@@ -809,7 +818,7 @@ sdks:
             distribution-type: package
             distribution-repository: GitHub
             package-name: Go
-            location: https://github.com/pubnub/go/releases/tag/8.0.0
+            location: https://github.com/pubnub/go/releases/tag/v8.1.0
             requires:
               -
                 name: "Go"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v8.1.0
+November 17 2025
+
+#### Added
+- Add new logging system with `LoggerManager` supporting multiple custom loggers, structured log message types (network requests/responses, errors, user inputs), and PNLogger interface. Includes `DefaultLogger` with configurable log levels and detailed SDK operation logging. The new Config.Loggers field replaces deprecated Config.Log while maintaining backward compatibility.
+
+#### Modified
+- Refactor logs across the whole SDK. Now logs have dedicated structure and type, so only intended type will be printed. There is now much more logs, especially in internal systems.
+- Deprecate the old Logger. The old logger is still working (for backward compatibility) and is default to `PNLogLevelDebug`.
+
 ## v8.0.0
 October 29 2025
 

--- a/add_channel_channel_group_request.go
+++ b/add_channel_channel_group_request.go
@@ -62,9 +62,19 @@ func (b *addChannelToChannelGroupBuilder) QueryParam(queryParam map[string]strin
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *addChannelOpts) GetLogParams() map[string]interface{} {
+	return map[string]interface{}{
+		"Channels":     o.Channels,
+		"ChannelGroup": o.ChannelGroup,
+	}
+}
+
 // Execute runs AddChannelToChannelGroup request
 func (b *addChannelToChannelGroupBuilder) Execute() (
 	*AddChannelToChannelGroupResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNAddChannelsToChannelGroupOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyAddChannelToChannelGroupResp, status, err

--- a/add_channels_to_push_request.go
+++ b/add_channels_to_push_request.go
@@ -68,8 +68,26 @@ func (b *addPushNotificationsOnChannelsBuilder) QueryParam(queryParam map[string
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *addChannelsToPushOpts) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"Channels":        o.Channels,
+		"PushType":        o.PushType,
+		"DeviceIDForPush": o.DeviceIDForPush,
+	}
+	if o.Topic != "" {
+		params["Topic"] = o.Topic
+	}
+	if o.Environment != "" {
+		params["Environment"] = o.Environment
+	}
+	return params
+}
+
 // Execute runs add Push Notifications on channels request
 func (b *addPushNotificationsOnChannelsBuilder) Execute() (*AddPushNotificationsOnChannelsResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNPushNotificationsEnabledChannelsOperation, b.opts.GetLogParams(), true)
+	
 	_, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyAddPushNotificationsOnChannelsResponse, status, err

--- a/config.go
+++ b/config.go
@@ -203,7 +203,7 @@ func (c *Config) GetLogString() string {
 		c.PublishKey,
 		c.SubscribeKey,
 		maskIfNotEmpty(c.SecretKey),
-		c.AuthKey,
+		maskIfNotEmpty(c.AuthKey),
 		c.Origin,
 		c.UUID,
 		maskIfNotEmpty(c.CipherKey),

--- a/config.go
+++ b/config.go
@@ -42,7 +42,8 @@ type Config struct {
 	MaximumLatencyDataAge        int                // Max time to store the latency data for telemetry
 	FilterExpression             string             // Feature to subscribe with a custom filter expression.
 	PNReconnectionPolicy         ReconnectionPolicy // Reconnection policy selection
-	Log                          *log.Logger        // Logger instance
+	Log                          *log.Logger        // Deprecated: Logger instance. Use Loggers instead for enhanced logging.
+	Loggers                      []PNLogger         // Custom loggers for enhanced logging. If empty, no logging will occur unless the deprecated Log field is set.
 	SuppressLeaveEvents          bool               // When true the SDK doesn't send out the leave requests.
 	DisablePNOtherProcessing     bool               // PNOther processing looks for pn_other in the JSON on the recevied message
 	UseHTTP2                     bool               // HTTP2 Flag

--- a/config.go
+++ b/config.go
@@ -56,6 +56,8 @@ type Config struct {
 	//DEPRECATED: please use CryptoModule
 	UseRandomInitializationVector bool                // When true the IV will be random for all requests and not just file upload. When false the IV will be hardcoded for all requests except File Upload
 	CryptoModule                  crypto.CryptoModule // A cryptography module used for encryption and decryption
+
+	validationWarnings []string // Internal field to store validation warnings during config setup
 }
 
 // NewDemoConfig initiates the config with demo keys, for tests only.
@@ -103,9 +105,11 @@ func NewConfig(uuid string) *Config {
 
 func (c *Config) checkMinTimeout(timeout int) int {
 	if timeout < minTimeout {
-		if c.Log != nil {
-			c.Log.Println(fmt.Sprintf("PresenceTimeout value less than the min recommended value of %[1]d, setting value to %[1]d %d", minTimeout, timeout))
-		}
+		warning := fmt.Sprintf("PresenceTimeout value %d is less than the min recommended value of %d, adjusting to %d", timeout, minTimeout, minTimeout)
+
+		// Store warning to be logged when PubNub instance is created
+		c.validationWarnings = append(c.validationWarnings, warning)
+
 		timeout = minTimeout
 	}
 	return timeout
@@ -142,4 +146,89 @@ func (c *Config) SetUserId(userId UserId) *Config {
 // GetUserId gets value of userId
 func (c *Config) GetUserId() UserId {
 	return UserId(c.UUID)
+}
+
+// GetLogString returns a formatted string representation of the Config for logging purposes.
+// Sensitive fields (SecretKey, CipherKey) are masked with ***.
+func (c *Config) GetLogString() string {
+	c.RLock()
+	defer c.RUnlock()
+
+	maskIfNotEmpty := func(value string) string {
+		if value != "" {
+			return "***"
+		}
+		return ""
+	}
+
+	cryptoModuleStr := "<nil>"
+	if c.CryptoModule != nil {
+		cryptoModuleStr = "<configured>"
+	}
+
+	loggersStr := fmt.Sprintf("%d logger(s)", len(c.Loggers))
+
+	return fmt.Sprintf(`Config{
+  PublishKey: %s
+  SubscribeKey: %s
+  SecretKey: %s
+  AuthKey: %s
+  Origin: %s
+  UUID: %s
+  CipherKey: %s
+  Secure: %t
+  ConnectTimeout: %d
+  NonSubscribeRequestTimeout: %d
+  SubscribeRequestTimeout: %d
+  FileUploadRequestTimeout: %d
+  HeartbeatInterval: %d
+  PresenceTimeout: %d
+  MaximumReconnectionRetries: %d
+  MaximumLatencyDataAge: %d
+  FilterExpression: %s
+  PNReconnectionPolicy: %s
+  SuppressLeaveEvents: %t
+  DisablePNOtherProcessing: %t
+  UseHTTP2: %t
+  MessageQueueOverflowCount: %d
+  MaxIdleConnsPerHost: %d
+  MaxWorkers: %d
+  UsePAMV3: %t
+  StoreTokensOnGrant: %t
+  FileMessagePublishRetryLimit: %d
+  UseRandomInitializationVector: %t
+  CryptoModule: %s
+  Loggers: %s
+}`,
+		c.PublishKey,
+		c.SubscribeKey,
+		maskIfNotEmpty(c.SecretKey),
+		c.AuthKey,
+		c.Origin,
+		c.UUID,
+		maskIfNotEmpty(c.CipherKey),
+		c.Secure,
+		c.ConnectTimeout,
+		c.NonSubscribeRequestTimeout,
+		c.SubscribeRequestTimeout,
+		c.FileUploadRequestTimeout,
+		c.HeartbeatInterval,
+		c.PresenceTimeout,
+		c.MaximumReconnectionRetries,
+		c.MaximumLatencyDataAge,
+		c.FilterExpression,
+		c.PNReconnectionPolicy,
+		c.SuppressLeaveEvents,
+		c.DisablePNOtherProcessing,
+		c.UseHTTP2,
+		c.MessageQueueOverflowCount,
+		c.MaxIdleConnsPerHost,
+		c.MaxWorkers,
+		c.UsePAMV3,
+		c.StoreTokensOnGrant,
+		c.FileMessagePublishRetryLimit,
+		c.UseRandomInitializationVector,
+		cryptoModuleStr,
+		loggersStr,
+	)
 }

--- a/delete_channel_group_request.go
+++ b/delete_channel_group_request.go
@@ -47,9 +47,18 @@ func (b *deleteChannelGroupBuilder) QueryParam(queryParam map[string]string) *de
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *deleteChannelGroupOpts) GetLogParams() map[string]interface{} {
+	return map[string]interface{}{
+		"ChannelGroup": o.ChannelGroup,
+	}
+}
+
 // Execute runs the DeleteChannelGroup request.
 func (b *deleteChannelGroupBuilder) Execute() (
 	*DeleteChannelGroupResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNRemoveGroupOperation, b.opts.GetLogParams(), true)
+	
 	_, status, err := executeRequest(b.opts)
 
 	if err != nil {

--- a/endpoints.go
+++ b/endpoints.go
@@ -36,6 +36,7 @@ type endpoint interface {
 	operationType() OperationType
 	telemetryManager() *TelemetryManager
 	tokenManager() *TokenManager
+	getPubNub() *PubNub
 }
 
 func (o *endpointOpts) config() *Config {
@@ -52,6 +53,10 @@ func (o *endpointOpts) context() Context {
 
 func (o *endpointOpts) jobQueue() chan *JobQItem {
 	return o.pubnub.jobQueue
+}
+
+func (o *endpointOpts) getPubNub() *PubNub {
+	return o.pubnub
 }
 
 func (o *endpointOpts) buildBody() ([]byte, error) {
@@ -173,7 +178,7 @@ func buildURL(o endpoint) (*url.URL, error) {
 			signedInput += fmt.Sprintf("%s\n", path)
 
 			signedInput += utils.PreparePamParams(query)
-			o.config().Log.Println("signedInput:", signedInput)
+			o.getPubNub().loggerManager.LogSimple(PNLogLevelTrace, fmt.Sprintf("PAM: signedInput=%s", signedInput), false)
 
 			signature = utils.GetHmacSha256(o.config().SecretKey, signedInput)
 		} else {
@@ -266,7 +271,7 @@ func createSignatureV2(o endpoint, path string, query *url.Values) string {
 	if err == nil {
 		bodyString = string(b)
 	} else {
-		o.config().Log.Println("buildBody error", err.Error())
+		o.getPubNub().loggerManager.LogSimple(PNLogLevelWarn, fmt.Sprintf("PAM: buildBody error: %v", err.Error()), false)
 	}
 
 	sig := createSignatureV2FromStrings(
@@ -279,7 +284,7 @@ func createSignatureV2(o endpoint, path string, query *url.Values) string {
 		o.config().Log,
 	)
 
-	o.config().Log.Println("signaturev2:", sig)
+	o.getPubNub().loggerManager.LogSimple(PNLogLevelTrace, fmt.Sprintf("PAM: signaturev2=%s", sig), false)
 	return sig
 }
 

--- a/endpoints.go
+++ b/endpoints.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"log"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -281,22 +280,18 @@ func createSignatureV2(o endpoint, path string, query *url.Values) string {
 		fmt.Sprintf("%s", path),
 		utils.PreparePamParams(query),
 		bodyString,
-		o.config().Log,
 	)
 
 	o.getPubNub().loggerManager.LogSimple(PNLogLevelTrace, fmt.Sprintf("PAM: signaturev2=%s", sig), false)
 	return sig
 }
 
-func createSignatureV2FromStrings(httpMethod, pubKey, secKey, path, query, body string, l *log.Logger) string {
+func createSignatureV2FromStrings(httpMethod, pubKey, secKey, path, query, body string) string {
 	signedInputV2 := httpMethod + "\n"
 	signedInputV2 += pubKey + "\n"
 	signedInputV2 += path + "\n"
 	signedInputV2 += query + "\n"
 	signedInputV2 += body
-	if l != nil {
-		l.Println("signedInputV2:", signedInputV2)
-	}
 
 	encoded := utils.GetHmacSha256(secKey, signedInputV2)
 	encoded = strings.TrimRight(encoded, "=")

--- a/endpoints_test.go
+++ b/endpoints_test.go
@@ -36,7 +36,7 @@ func TestSignatureV2(t *testing.T) {
     }
   }
 }`
-	sigv2 := createSignatureV2FromStrings(httpMethod, pubKey, secKey, path, query, body, nil)
+	sigv2 := createSignatureV2FromStrings(httpMethod, pubKey, secKey, path, query, body)
 	assert.Equal("v2.k80LsDMD-sImA8rCBj-ntRKhZ8mSjHY8Ivngt9W3Yc4", sigv2)
 }
 
@@ -47,7 +47,7 @@ func TestSignatureV2_1(t *testing.T) {
 	secKey := "sec-c-MmUxNTZjMmYtNzFkNS00OAkzLWE2YjctNmQ4YzE5NWNmZDA3"
 	path := "/v1/objects/sub-c-d7da9e59-c997-11e9-a139-dab2c75acd6f/spaces/pandu-ut-sid/users"
 	query := "l_obj=0.4545555556&l_pam=1.145&pnsdk=PubNubCSharp4.0.34.0&requestid=19e1dee9-2f87-45d6-97e5-3f4d3f9779a2&timestamp=1568724043&uuid=mytestuuid"
-	sigv2 := createSignatureV2FromStrings(httpMethod, pubKey, secKey, path, query, "", nil)
+	sigv2 := createSignatureV2FromStrings(httpMethod, pubKey, secKey, path, query, "")
 	assert.Equal("v2.TcZdUURiXAnxJgN4OLPczxzH4MQO87l-yKfE4fyUHGc", sigv2)
 }
 
@@ -58,7 +58,7 @@ func TestSignatureV2_2(t *testing.T) {
 	secKey := "sec-c-ZDkzZTBkOTEtNTQxZS00VmQ3LTljMWUtMTNiNGZjNWUwMTVk"
 	path := "/v1/objects/sub-c-c9710929-1b7a-11e3-a0c8-02ee2ddab7fe/users"
 	query := "count=true&filter=name%3D%3D%27newnamemodified%27&include=custom&pnsdk=NET461CSharp4.5.0.0&timestamp=1577364610&uuid=pn-856feea0-5ba3-4c6d-85a2-a67efa1f4e20"
-	sigv2 := createSignatureV2FromStrings(httpMethod, pubKey, secKey, path, query, "", nil)
+	sigv2 := createSignatureV2FromStrings(httpMethod, pubKey, secKey, path, query, "")
 	assert.Equal("v2.w39EWDHc0ibDCxOD2jiJEutjpc_1VJ1SDyGaABEljSs", sigv2)
 }
 
@@ -70,7 +70,7 @@ func TestSignatureV2_granttoken(t *testing.T) {
 	path := "/v3/pam/sub-c-4757f09c-c3f2-11e9-9d00-8a58a5558306/grant"
 	query := "pnsdk=PubNub-Go%2F4.6.5&timestamp=1583755527&uuid=pn-f1df31f1-6ba9-49e1-ae72-084c15404302"
 	body := `{"ttl":10,"permissions":{"resources":{"channels":{},"groups":{},"users":{"u1":7,"u2":7},"spaces":{"s1":31,"s2":31}},"patterns":{"channels":{},"groups":{},"users":{"^u-[0-9a-f]*$":15},"spaces":{"^s-[0-9a-f]*$":27}},"meta":{}}}`
-	sigv2 := createSignatureV2FromStrings(httpMethod, pubKey, secKey, path, query, body, nil)
+	sigv2 := createSignatureV2FromStrings(httpMethod, pubKey, secKey, path, query, body)
 	assert.Equal("v2.Dd2YCsd-Ds_fFpGyuHIetndf2UrgZ-FTwcLggcPfx98", sigv2)
 }
 
@@ -82,7 +82,7 @@ func TestSignatureV2_3(t *testing.T) {
 	path := "/v3/pam/sub-c-4757f09c-c3f2-11e9-9d00-8a58a5558306/grant"
 	query := "timestamp=1583479519"
 	body := `{"ttl":"3","permissions":{"resources":{"channels":{},"groups":{},"users":{"userid9820":31,"userid1962":31},"spaces":{"spaceid9820":31,"spaceid1962":31}},"patterns":{"channels":{},"groups":{},"users":{},"spaces":{}},"meta":{}}}`
-	sigv2 := createSignatureV2FromStrings(httpMethod, pubKey, secKey, path, query, body, nil)
+	sigv2 := createSignatureV2FromStrings(httpMethod, pubKey, secKey, path, query, body)
 	assert.Equal("v2.GbQoBigWGAHX9BAFOlr84nW8XO9QgNob9g21KEr1KfA", sigv2)
 }
 
@@ -94,7 +94,7 @@ func TestSignatureV2_4(t *testing.T) {
 	path := "/v3/pam/sub-c-4757f09c-c3f2-11e9-9d00-8a58a5558306/grant"
 	query := "timestamp=1583486135"
 	body := `{"ttl":"3","permissions":{"resources":{"channels":{},"groups":{},"users":{"userid6155":31,"userid7504":31},"spaces":{"spaceid6155":31,"spaceid7504":31}},"patterns":{"channels":{},"groups":{},"users":{},"spaces":{}},"meta":{}}}`
-	sigv2 := createSignatureV2FromStrings(httpMethod, pubKey, secKey, path, query, body, nil)
+	sigv2 := createSignatureV2FromStrings(httpMethod, pubKey, secKey, path, query, body)
 	assert.Equal("v2.Md5iDqxLLCU1wj3L6wUmsrbW6IrOuhZyPEi1AwdsELs", sigv2)
 }
 
@@ -106,7 +106,7 @@ func TestSignatureV2_5(t *testing.T) {
 	path := "/v3/pam/sub-c-4757f09c-c3f2-11e9-9d00-8a58a5558306/grant"
 	query := "timestamp=1583486728"
 	body := `{"ttl":"3","permissions":{"resources":{"channels":{},"groups":{},"users":{"userid4289":31,"userid4476":31},"spaces":{"spaceid4289":31,"spaceid4476":31}},"patterns":{"channels":{},"groups":{},"users":{},"spaces":{}},"meta":{}}}`
-	sigv2 := createSignatureV2FromStrings(httpMethod, pubKey, secKey, path, query, body, nil)
+	sigv2 := createSignatureV2FromStrings(httpMethod, pubKey, secKey, path, query, body)
 	assert.Equal("v2._LxrtaeGughFMF7aFMnzqpLAjM9JT4ELlUjVNskXgDs", sigv2)
 }
 
@@ -118,6 +118,6 @@ func TestSignatureV2_6(t *testing.T) {
 	path := "/v1/objects/sub-c-4757f09c-c3f2-11e9-9d00-8a58a5558306/users"
 	query := "include=custom&pnsdk=PubNub-Go/4.6.5&timestamp=1583493622&uuid=pn-01fb5308-f0ce-480b-b051-6ff98ba22467"
 	body := `{"id":"id0","name":"name","externalId":"extid","profileUrl":"purl","email":"email","custom":{"a":"b","c":"d"}}`
-	sigv2 := createSignatureV2FromStrings(httpMethod, pubKey, secKey, path, query, body, nil)
+	sigv2 := createSignatureV2FromStrings(httpMethod, pubKey, secKey, path, query, body)
 	assert.Equal("v2.a--gef4a6Rm3Oe7k2pPOP9IbjRPWi5Ky-RKpIcQIYn0", sigv2)
 }

--- a/enums.go
+++ b/enums.go
@@ -9,6 +9,9 @@ import (
 // in the APIs lifecycle
 type StatusCategory int
 
+// PubNubLogLevel is used as an enum to catgorize the available log levels
+type PNLogLevel int
+
 // OperationType is used as an enum to catgorize the various operations
 // in the APIs lifecycle
 type OperationType int
@@ -42,6 +45,22 @@ type PNMessageActionsEventType string
 
 // PNPushEnvironment is used as an enum to catgorize the available Message Actions Event types
 type PNPushEnvironment string
+
+// PNLogLevel constants define the available log levels
+const (
+	// PNLogLevelTrace is the enum when the log level is trace
+	PNLogLevelTrace PNLogLevel = 1 + iota
+	// PNLogLevelDebug is the enum when the log level is debug
+	PNLogLevelDebug
+	// PNLogLevelInfo is the enum when the log level is info
+	PNLogLevelInfo
+	// PNLogLevelWarn is the enum when the log level is warn
+	PNLogLevelWarn
+	// PNLogLevelError is the enum when the log level is error
+	PNLogLevelError
+	// PNLogLevelNone is the enum when the log level is none
+	PNLogLevelNone
+)
 
 const (
 	//PNPushEnvironmentDevelopment for development
@@ -353,6 +372,25 @@ const (
 	// PNPushTypeFCM is used as an enum to for selecting `FCM` as the PNPushType
 	PNPushTypeFCM
 )
+
+func (l PNLogLevel) String() string {
+	switch l {
+	case PNLogLevelTrace:
+		return "Trace"
+	case PNLogLevelDebug:
+		return "Debug"
+	case PNLogLevelInfo:
+		return "Info"
+	case PNLogLevelWarn:
+		return "Warn"
+	case PNLogLevelError:
+		return "Error"
+	case PNLogLevelNone:
+		return "None"
+	default:
+		return "None"
+	}
+}
 
 func (p PNPushType) String() string {
 	switch p {

--- a/enums.go
+++ b/enums.go
@@ -177,6 +177,19 @@ const (
 	PNExponentialPolicy
 )
 
+func (p ReconnectionPolicy) String() string {
+	switch p {
+	case PNNonePolicy:
+		return "None"
+	case PNLinearPolicy:
+		return "Linear"
+	case PNExponentialPolicy:
+		return "Exponential"
+	default:
+		return "Unknown"
+	}
+}
+
 const (
 	// PNMessageTypeSignal is to identify Signal the Subscribe response
 	PNMessageTypeSignal PNMessageType = 1 + iota

--- a/examples/snippets/api/logging_example_test.go
+++ b/examples/snippets/api/logging_example_test.go
@@ -4,7 +4,6 @@ package pubnub_samples_test
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	pubnub "github.com/pubnub/go/v8"
@@ -29,9 +28,9 @@ When copying examples to your own code:
 - Remove any statements that are between snippet.hide and snippet.show (they're only for testing purposes)
 */
 
-// snippet.logging
-// Example_logging demonstrates how to enable logging in the PubNub Go SDK
-func Example_logging() {
+// snippet.logging-simple
+// Example_loggingSimple demonstrates how to enable simple console logging in the PubNub Go SDK
+func Example_loggingSimple() {
 	// Create a new PubNub configuration
 	config := pubnub.NewConfigWithUserId(pubnub.UserId("loggingDemoUser"))
 
@@ -44,8 +43,53 @@ func Example_logging() {
 	config = setPubnubExampleConfigData(config)
 	// snippet.show
 
-	// Set up logging
-	var infoLogger *log.Logger
+	// Create a simple console logger with INFO level (shows Info, Warn, Error)
+	// Logs will be written to stdout with timestamps
+	simpleLogger := pubnub.NewDefaultLogger(pubnub.PNLogLevelInfo)
+
+	// Add the logger to the config
+	config.Loggers = []pubnub.PNLogger{simpleLogger}
+
+	// Initialize PubNub with the configured settings
+	pn := pubnub.NewPubNub(config)
+
+	// Perform operations - they will be logged to console
+	_, _, err := pn.Time().Execute()
+	if err != nil {
+		fmt.Println("Error fetching time:", err)
+	} else {
+		fmt.Println("Time fetched successfully")
+	}
+
+	// Publish a message to demonstrate logging
+	_, status, err := pn.Publish().
+		Channel("logging-demo-channel").
+		Message("Hello from Logging Example").
+		Execute()
+
+	if err != nil {
+		fmt.Printf("Error publishing message: %v\n", err)
+	} else {
+		fmt.Printf("Publish status: %d\n", status.StatusCode)
+		fmt.Println("Check console output for detailed logging information")
+	}
+}
+
+// snippet.end
+
+// snippet.logging-file
+// Example_loggingToFile demonstrates how to log PubNub operations to a file
+func Example_loggingToFile() {
+	// Create a new PubNub configuration
+	config := pubnub.NewConfigWithUserId(pubnub.UserId("loggingDemoUser"))
+
+	// Set the subscribe and publish keys
+	config.SubscribeKey = "demo"
+	config.PublishKey = "demo"
+
+	// snippet.hide
+	config = setPubnubExampleConfigData(config)
+	// snippet.show
 
 	// Specify log file name
 	logfileName := "pubnubMessaging.log"
@@ -59,24 +103,26 @@ func Example_logging() {
 	if err != nil {
 		fmt.Println("Error opening log file:", err.Error())
 		fmt.Println("Logging disabled")
-	} else {
-		// snippet.hide
-		defer f.Close()
-		// snippet.show
-		fmt.Println("Logging enabled, writing to", logfileName)
-
-		// Create a new logger with timestamp and file information
-		infoLogger = log.New(f, "", log.Ldate|log.Ltime|log.Lshortfile)
-
-		// Set the logger in the PubNub config
-		config.Log = infoLogger
-		config.Log.SetPrefix("PubNub :=  ")
+		return
 	}
+
+	// snippet.hide
+	defer f.Close()
+	// snippet.show
+
+	fmt.Println("Logging enabled, writing to", logfileName)
+
+	// Create a logger that writes to the file with DEBUG level
+	// This will log Debug, Info, Warn, and Error messages
+	fileLogger := pubnub.NewDefaultLoggerWithWriter(pubnub.PNLogLevelDebug, f)
+
+	// Add the logger to the config
+	config.Loggers = []pubnub.PNLogger{fileLogger}
 
 	// Initialize PubNub with the configured settings
 	pn := pubnub.NewPubNub(config)
 
-	// Perform an operation to generate log entries
+	// Perform operations - they will be logged to the file
 	_, _, err = pn.Time().Execute()
 	if err != nil {
 		fmt.Println("Error fetching time:", err)
@@ -87,7 +133,7 @@ func Example_logging() {
 	// Publish a message to demonstrate logging
 	_, status, err := pn.Publish().
 		Channel("logging-demo-channel").
-		Message("Hello from Logging Example").
+		Message("Hello from File Logging Example").
 		Execute()
 
 	if err != nil {
@@ -98,13 +144,171 @@ func Example_logging() {
 	}
 
 	fmt.Println("Example complete. Logging information has been saved to", logfileName)
+}
 
-	// Output:
-	// Logging enabled, writing to pubnubMessaging.log
-	// Time fetched successfully, check the log file for details
-	// Publish status: 200
-	// Check the log file for detailed logging information
-	// Example complete. Logging information has been saved to pubnubMessaging.log
+// snippet.end
+
+// snippet.logging-multiple
+// Example_loggingMultiple demonstrates how to use multiple loggers with different log levels
+func Example_loggingMultiple() {
+	// Create a new PubNub configuration
+	config := pubnub.NewConfigWithUserId(pubnub.UserId("loggingDemoUser"))
+
+	// Set the subscribe and publish keys
+	config.SubscribeKey = "demo"
+	config.PublishKey = "demo"
+
+	// snippet.hide
+	config = setPubnubExampleConfigData(config)
+	// snippet.show
+
+	// Create multiple loggers for different purposes
+
+	// 1. Console logger for errors only (production-friendly)
+	consoleLogger := pubnub.NewDefaultLogger(pubnub.PNLogLevelError)
+
+	// 2. File logger for detailed debugging
+	debugLogFile := "pubnub-debug.log"
+	// snippet.hide
+	defer os.Remove(debugLogFile)
+	// snippet.show
+
+	f, err := os.OpenFile(debugLogFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	if err != nil {
+		fmt.Println("Error opening debug log file:", err.Error())
+		return
+	}
+	// snippet.hide
+	defer f.Close()
+	// snippet.show
+
+	debugLogger := pubnub.NewDefaultLoggerWithWriter(pubnub.PNLogLevelDebug, f)
+
+	// Add both loggers to the config
+	// Errors will go to console, all debug info will go to file
+	config.Loggers = []pubnub.PNLogger{consoleLogger, debugLogger}
+
+	// Initialize PubNub with the configured settings
+	pn := pubnub.NewPubNub(config)
+
+	fmt.Println("Multiple loggers configured:")
+	fmt.Println("- Console: ERROR level only")
+	fmt.Println("- File: DEBUG level and above")
+
+	// Perform operations
+	_, _, err = pn.Time().Execute()
+	if err != nil {
+		fmt.Println("Error fetching time:", err)
+	} else {
+		fmt.Println("Time fetched successfully")
+	}
+
+	// Publish a message
+	_, status, err := pn.Publish().
+		Channel("logging-demo-channel").
+		Message("Hello with multiple loggers").
+		Execute()
+
+	if err != nil {
+		fmt.Printf("Error publishing message: %v\n", err)
+	} else {
+		fmt.Printf("Publish status: %d\n", status.StatusCode)
+	}
+
+	fmt.Println("Errors (if any) appear on console, all details in", debugLogFile)
+}
+
+// snippet.end
+
+// snippet.logging-custom
+// Example_loggingCustom demonstrates how to create a custom logger implementation
+
+// CustomStructuredLogger is an example implementation of a custom logger
+// that outputs structured logs in JSON-like format
+type CustomStructuredLogger struct {
+	minLevel pubnub.PNLogLevel
+}
+
+// Log implements the PNLogger interface
+func (l *CustomStructuredLogger) Log(logMessage pubnub.LogMessage) {
+	// Only log messages at or above the configured level
+	if logMessage.GetLogLevel() < l.minLevel {
+		return
+	}
+
+	// Output structured log in a custom format
+	// In a real implementation, you might output JSON or send to a logging service
+	fmt.Printf("[%s] level=%s instance=%s message=%q\n",
+		logMessage.GetTimestamp().Format("2006-01-02 15:04:05.000"),
+		logMessage.GetLogLevel().String(),
+		logMessage.GetInstanceID(),
+		logMessage.GetMessage(),
+	)
+
+	// Handle specific message types using type assertions
+	switch msg := logMessage.(type) {
+	case pubnub.ErrorLogMessage:
+		// If it's an error message, include error details
+		fmt.Printf("  error_name=%s operation=%s error_details=%q\n",
+			msg.ErrorName,
+			msg.Operation.String(),
+			msg.Error.Error(),
+		)
+	case pubnub.UserInputLogMessage:
+		// If it's a user input message, include parameters
+		fmt.Printf("  operation=%s user_params=%v\n",
+			msg.Operation.String(),
+			msg.Parameters,
+		)
+	case pubnub.NetworkRequestLogMessage:
+		// If it's a network request, include HTTP details
+		fmt.Printf("  method=%s url=%s\n",
+			msg.Method,
+			msg.URL,
+		)
+	}
+}
+
+// GetMinLogLevel implements the PNLogger interface
+func (l *CustomStructuredLogger) GetMinLogLevel() pubnub.PNLogLevel {
+	return l.minLevel
+}
+
+func Example_loggingCustom() {
+	// Create a new PubNub configuration
+	config := pubnub.NewConfigWithUserId(pubnub.UserId("loggingDemoUser"))
+
+	config.SubscribeKey = "demo"
+	config.PublishKey = "demo"
+
+	// snippet.hide
+	config = setPubnubExampleConfigData(config)
+	// snippet.show
+
+	// Create an instance of our custom logger
+	customLogger := &CustomStructuredLogger{
+		minLevel: pubnub.PNLogLevelInfo,
+	}
+
+	// Add the custom logger to the config
+	config.Loggers = []pubnub.PNLogger{customLogger}
+
+	// Initialize PubNub with the configured settings
+	pn := pubnub.NewPubNub(config)
+
+	fmt.Println("Custom structured logger configured")
+
+	// Perform operations
+	_, status, err := pn.Publish().
+		Channel("logging-demo-channel").
+		Message("Hello from custom logger").
+		Execute()
+
+	if err != nil {
+		fmt.Printf("Error publishing message: %v\n", err)
+	} else {
+		fmt.Printf("Publish status: %d\n", status.StatusCode)
+	}
 }
 
 // snippet.end

--- a/examples/snippets/api/objects_example_test.go
+++ b/examples/snippets/api/objects_example_test.go
@@ -4,6 +4,7 @@ package pubnub_samples_test
 
 import (
 	"fmt"
+	"time"
 
 	pubnub "github.com/pubnub/go/v8"
 )
@@ -94,6 +95,9 @@ func Example_getUUIDMetadata() {
 		Name("Jane Smith").
 		Email("jane@example.com").
 		Execute()
+
+	// Small delay to ensure metadata is persisted before retrieval
+	time.Sleep(2 * time.Second)
 
 	// Then retrieve the user metadata
 	response, status, err := pn.GetUUIDMetadata().
@@ -366,6 +370,9 @@ func Example_getChannelMetadata() {
 		Description("Sales team discussions").
 		Execute()
 
+	// Small delay to ensure metadata is persisted before retrieval
+	time.Sleep(2 * time.Second)
+
 	// Then retrieve the channel metadata
 	response, status, err := pn.GetChannelMetadata().
 		Channel("sales-channel-456"). // Channel ID to retrieve
@@ -414,6 +421,9 @@ func Example_getChannelMetadataWithIncludes() {
 		Status("active").
 		Type("public").
 		Execute()
+
+	// Small delay to ensure metadata is persisted before retrieval
+	time.Sleep(2 * time.Second)
 
 	// Get channel metadata with all include options
 	response, status, err := pn.GetChannelMetadata().
@@ -662,6 +672,9 @@ func Example_getMemberships() {
 		}).
 		Execute()
 
+	// Small delay to ensure metadata is persisted before retrieval
+	time.Sleep(2 * time.Second)
+
 	// Get all channels the user is a member of
 	response, status, err := pn.GetMemberships().
 		UUID("member-user-999"). // User ID
@@ -737,6 +750,9 @@ func Example_getMembershipsWithAllIncludes() {
 			},
 		}).
 		Execute()
+
+	// Small delay to ensure metadata is persisted before retrieval
+	time.Sleep(2 * time.Second)
 
 	// Get memberships with all include options
 	response, status, err := pn.GetMemberships().
@@ -976,6 +992,9 @@ func Example_getChannelMembers() {
 		}).
 		Execute()
 
+	// Small delay to ensure metadata is persisted before retrieval
+	time.Sleep(2 * time.Second)
+
 	// Get all members of the channel
 	response, status, err := pn.GetChannelMembers().
 		Channel("project-channel-777"). // Channel ID
@@ -1051,6 +1070,9 @@ func Example_getChannelMembersWithAllIncludes() {
 			},
 		}).
 		Execute()
+
+	// Small delay to ensure metadata is persisted before retrieval
+	time.Sleep(2 * time.Second)
 
 	// Get channel members with all include options
 	response, status, err := pn.GetChannelMembers().

--- a/examples/snippets/api/pubsub_example_test.go
+++ b/examples/snippets/api/pubsub_example_test.go
@@ -346,8 +346,8 @@ func Example_subscribe() {
 	fmt.Println("Subscribed to channel")
 
 	// When done, unsubscribe and stop goroutine
-	pn.UnsubscribeAll()
 	close(done)
+	pn.UnsubscribeAll()
 
 	// Output:
 	// Subscribed to channel

--- a/examples/snippets/api/pubsub_example_test.go
+++ b/examples/snippets/api/pubsub_example_test.go
@@ -352,16 +352,14 @@ func Example_subscribe() {
 	fmt.Println("Subscribed to channel")
 
 	// When done, unsubscribe and stop goroutine
-	close(done)
 	pn.UnsubscribeAll()
+	close(done)
 
 	// snippet.hide
 	// Small delay to ensure cleanup completes before next example
 	time.Sleep(100 * time.Millisecond)
 	// snippet.show
 
-	// Output:
-	// Subscribed to channel
 }
 
 // snippet.subscribe_multiple

--- a/examples/snippets/api/pubsub_example_test.go
+++ b/examples/snippets/api/pubsub_example_test.go
@@ -4,6 +4,7 @@ package pubnub_samples_test
 
 import (
 	"fmt"
+	"time"
 
 	pubnub "github.com/pubnub/go/v8"
 )
@@ -288,6 +289,11 @@ func Example_subscribeBasicWithLogging() {
 	// Cleanup
 	pn.UnsubscribeAll()
 
+	// snippet.hide
+	// Small delay to ensure cleanup completes before next example
+	time.Sleep(100 * time.Millisecond)
+	// snippet.show
+
 	// Output:
 	// Subscribed to my-channel
 }
@@ -349,6 +355,11 @@ func Example_subscribe() {
 	close(done)
 	pn.UnsubscribeAll()
 
+	// snippet.hide
+	// Small delay to ensure cleanup completes before next example
+	time.Sleep(100 * time.Millisecond)
+	// snippet.show
+
 	// Output:
 	// Subscribed to channel
 }
@@ -401,6 +412,11 @@ func Example_subscribeMultiple() {
 	// When done, unsubscribe and stop goroutine
 	pn.UnsubscribeAll()
 	close(done)
+
+	// snippet.hide
+	// Small delay to ensure cleanup completes before next example
+	time.Sleep(100 * time.Millisecond)
+	// snippet.show
 
 	// Output:
 	// Subscribed to multiple channels
@@ -461,6 +477,11 @@ func Example_subscribeWithPresence() {
 	pn.UnsubscribeAll()
 	close(done)
 
+	// snippet.hide
+	// Small delay to ensure cleanup completes before next example
+	time.Sleep(100 * time.Millisecond)
+	// snippet.show
+
 	// Output:
 	// Subscribed with presence
 }
@@ -513,6 +534,11 @@ func Example_subscribeWildcard() {
 	// When done, unsubscribe and stop goroutine
 	pn.UnsubscribeAll()
 	close(done)
+
+	// snippet.hide
+	// Small delay to ensure cleanup completes before next example
+	time.Sleep(100 * time.Millisecond)
+	// snippet.show
 
 	// Output:
 	// Subscribed to wildcard channels
@@ -576,6 +602,11 @@ func Example_subscribeWithState() {
 	<-done
 
 	pn.UnsubscribeAll()
+
+	// snippet.hide
+	// Small delay to ensure cleanup completes before next example
+	time.Sleep(100 * time.Millisecond)
+	// snippet.show
 
 	// Output:
 	// State set successfully
@@ -674,6 +705,11 @@ func Example_unsubscribeAll() {
 	pn.UnsubscribeAll()
 
 	fmt.Println("Unsubscribed from all channels")
+
+	// snippet.hide
+	// Small delay to ensure cleanup completes before next example
+	time.Sleep(100 * time.Millisecond)
+	// snippet.show
 
 	// Output:
 	// Unsubscribed from all channels

--- a/files_delete_file.go
+++ b/files_delete_file.go
@@ -65,8 +65,19 @@ func (b *deleteFileBuilder) Transport(tr http.RoundTripper) *deleteFileBuilder {
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *deleteFileOpts) GetLogParams() map[string]interface{} {
+	return map[string]interface{}{
+		"Channel": o.Channel,
+		"ID":      o.ID,
+		"Name":    o.Name,
+	}
+}
+
 // Execute runs the deleteFile request.
 func (b *deleteFileBuilder) Execute() (*PNDeleteFileResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNDeleteFileOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyDeleteFileResponse, status, err

--- a/files_download_file.go
+++ b/files_download_file.go
@@ -81,7 +81,7 @@ func (o *downloadFileOpts) GetLogParams() map[string]interface{} {
 
 func (b *downloadFileBuilder) Execute() (*PNDownloadFileResponse, StatusResponse, error) {
 	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNDownloadFileOperation, b.opts.GetLogParams(), true)
-	
+
 	u, _ := buildURL(b.opts)
 	stat := StatusResponse{
 		AffectedChannels: []string{b.opts.Channel},
@@ -115,8 +115,10 @@ func (b *downloadFileBuilder) Execute() (*PNDownloadFileResponse, StatusResponse
 		if b.opts.CipherKey != "" {
 			cryptoModule, e = crypto.NewLegacyCryptoModule(b.opts.CipherKey, true)
 			if e != nil {
+				b.opts.pubnub.loggerManager.LogError(e, "FileDownloadCryptoModuleInitFailed", PNDownloadFileOperation, true)
 				return nil, stat, e
 			}
+			b.opts.pubnub.loggerManager.LogSimple(PNLogLevelDebug, "Crypto Module initialized for file download: type=LegacyCryptoModule, randomIV=true", false)
 		}
 
 		r, e := cryptoModule.DecryptStream(resp.Body)

--- a/files_download_file.go
+++ b/files_download_file.go
@@ -118,13 +118,19 @@ func (b *downloadFileBuilder) Execute() (*PNDownloadFileResponse, StatusResponse
 				b.opts.pubnub.loggerManager.LogError(e, "FileDownloadCryptoModuleInitFailed", PNDownloadFileOperation, true)
 				return nil, stat, e
 			}
-			b.opts.pubnub.loggerManager.LogSimple(PNLogLevelDebug, "Crypto Module initialized for file download: type=LegacyCryptoModule, randomIV=true", false)
+			b.opts.pubnub.loggerManager.LogSimple(PNLogLevelDebug, `Crypto Module initialized for file download:
+				type: LegacyCryptoModule
+				cipherKey: ***
+				randomIV: true`, false)
 		}
 
+		b.opts.pubnub.loggerManager.LogSimple(PNLogLevelTrace, "Crypto: decrypting file", false)
 		r, e := cryptoModule.DecryptStream(resp.Body)
 		if e != nil {
+			b.opts.pubnub.loggerManager.LogSimple(PNLogLevelError, fmt.Sprintf("Crypto: decryption of file failed due to %v", e), false)
 			return nil, stat, e
 		}
+		b.opts.pubnub.loggerManager.LogSimple(PNLogLevelTrace, "Crypto: file decrypted successfully", false)
 		respDL = &PNDownloadFileResponse{
 			File: r,
 		}

--- a/files_get_file_url.go
+++ b/files_get_file_url.go
@@ -60,8 +60,19 @@ func (b *getFileURLBuilder) Transport(tr http.RoundTripper) *getFileURLBuilder {
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *getFileURLOpts) GetLogParams() map[string]interface{} {
+	return map[string]interface{}{
+		"Channel": o.Channel,
+		"ID":      o.ID,
+		"Name":    o.Name,
+	}
+}
+
 // Execute runs the getFileURL request.
 func (b *getFileURLBuilder) Execute() (*PNGetFileURLResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNGetFileURLOperation, b.opts.GetLogParams(), true)
+	
 	u, _ := buildURL(b.opts)
 
 	resp := &PNGetFileURLResponse{

--- a/files_list_files.go
+++ b/files_list_files.go
@@ -70,8 +70,22 @@ func (b *listFilesBuilder) Transport(tr http.RoundTripper) *listFilesBuilder {
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *listFilesOpts) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"Channel": o.Channel,
+		"Limit":   o.Limit,
+	}
+	if o.Next != "" {
+		params["Next"] = o.Next
+	}
+	return params
+}
+
 // Execute runs the listFiles request.
 func (b *listFilesBuilder) Execute() (*PNListFilesResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNListFilesOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyListFilesResponse, status, err

--- a/files_send_file_to_s3.go
+++ b/files_send_file_to_s3.go
@@ -155,10 +155,13 @@ func (o *sendFileToS3Opts) buildBodyMultipartFileUpload() (bytes.Buffer, *multip
 				o.pubnub.loggerManager.LogError(e, "FileUploadCryptoModuleInitFailed", PNSendFileToS3Operation, true)
 				return bytes.Buffer{}, writer, s, e
 			}
-			o.pubnub.loggerManager.LogSimple(PNLogLevelDebug, "Crypto Module initialized for file upload: type=LegacyCryptoModule, randomIV=true", false)
+			o.pubnub.loggerManager.LogSimple(PNLogLevelDebug, `Crypto Module initialized for file upload:
+				type: LegacyCryptoModule
+				cipherKey: ***
+				randomIV: true`, false)
 		}
 
-		e = encryptStreamAndCopyTo(cryptoModule, o.File, filePart)
+		e = encryptStreamAndCopyTo(cryptoModule, o.File, filePart, o.pubnub.loggerManager)
 		if e != nil {
 			o.pubnub.loggerManager.LogError(e, "FileUploadEncryptionFailed", PNSendFileToS3Operation, true)
 			return bytes.Buffer{}, writer, s, e

--- a/files_send_file_to_s3.go
+++ b/files_send_file_to_s3.go
@@ -155,6 +155,7 @@ func (o *sendFileToS3Opts) buildBodyMultipartFileUpload() (bytes.Buffer, *multip
 				o.pubnub.loggerManager.LogError(e, "FileUploadCryptoModuleInitFailed", PNSendFileToS3Operation, true)
 				return bytes.Buffer{}, writer, s, e
 			}
+			o.pubnub.loggerManager.LogSimple(PNLogLevelDebug, "Crypto Module initialized for file upload: type=LegacyCryptoModule, randomIV=true", false)
 		}
 
 		e = encryptStreamAndCopyTo(cryptoModule, o.File, filePart)

--- a/fire_request.go
+++ b/fire_request.go
@@ -149,7 +149,7 @@ func (b *fireBuilder) Execute() (*PublishResponse, StatusResponse, error) {
 		return emptyPublishResponse, status, err
 	}
 
-	return newPublishResponse(rawJSON, status)
+	return newPublishResponse(rawJSON, status, b.opts.pubnub.loggerManager)
 }
 
 func (o *fireOpts) validate() error {
@@ -186,7 +186,7 @@ func (o *fireOpts) buildPath() (string, error) {
 
 	if o.pubnub.getCryptoModule() != nil {
 		var msg string
-		if msg, err = serializeEncryptAndSerialize(o.pubnub.getCryptoModule(), o.Message, o.Serialize); err != nil {
+		if msg, err = serializeEncryptAndSerialize(o.pubnub.getCryptoModule(), o.Message, o.Serialize, o.pubnub.loggerManager); err != nil {
 			o.pubnub.loggerManager.LogError(err, "FireMessageSerializationFailed", PNFireOperation, true)
 			return "", err
 		}

--- a/fire_request.go
+++ b/fire_request.go
@@ -113,10 +113,37 @@ func (b *fireBuilder) QueryParam(queryParam map[string]string) *fireBuilder {
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *fireOpts) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"Channel":   o.Channel,
+		"UsePost":   o.UsePost,
+		"Serialize": o.Serialize,
+	}
+	if o.setTTL {
+		params["TTL"] = o.TTL
+	}
+	if o.Meta != nil {
+		params["Meta"] = fmt.Sprintf("%v", o.Meta)
+	}
+	// Truncate message for logging
+	if o.Message != nil {
+		msgStr := fmt.Sprintf("%v", o.Message)
+		if len(msgStr) > 100 {
+			params["Message"] = msgStr[:100] + "... (truncated)"
+		} else {
+			params["Message"] = msgStr
+		}
+	}
+	return params
+}
+
 // Execute runs the Fire request.
 func (b *fireBuilder) Execute() (*PublishResponse, StatusResponse, error) {
 	b.opts.ShouldStore = false
 	b.opts.DoNotReplicate = true
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNFireOperation, b.opts.GetLogParams(), true)
+
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyPublishResponse, status, err
@@ -160,7 +187,7 @@ func (o *fireOpts) buildPath() (string, error) {
 	if o.pubnub.getCryptoModule() != nil {
 		var msg string
 		if msg, err = serializeEncryptAndSerialize(o.pubnub.getCryptoModule(), o.Message, o.Serialize); err != nil {
-			o.pubnub.Config.Log.Printf("error in serializing: %v\n", err)
+			o.pubnub.loggerManager.LogError(err, "FireMessageSerializationFailed", PNFireOperation, true)
 			return "", err
 		}
 		message = []byte(msg)

--- a/fire_request.go
+++ b/fire_request.go
@@ -253,7 +253,7 @@ func (o *fireOpts) buildBody() ([]byte, error) {
 		}
 
 		if o.pubnub.getCryptoModule() != nil {
-			enc, err := encryptString(o.pubnub.getCryptoModule(), string(msg))
+			enc, err := encryptString(o.pubnub.getCryptoModule(), string(msg), o.pubnub.loggerManager)
 			if err != nil {
 				return []byte{}, err
 			}

--- a/get_state_request.go
+++ b/get_state_request.go
@@ -75,9 +75,23 @@ func (b *getStateBuilder) Transport(
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *getStateOpts) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"Channels":      o.Channels,
+		"ChannelGroups": o.ChannelGroups,
+	}
+	if o.UUID != "" {
+		params["UUID"] = o.UUID
+	}
+	return params
+}
+
 // Execute runs the the Get State request.
 func (b *getStateBuilder) Execute() (
 	*GetStateResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNGetStateOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyGetStateResp, status, err

--- a/grant_request.go
+++ b/grant_request.go
@@ -136,8 +136,34 @@ func (b *grantBuilder) QueryParam(queryParam map[string]string) *grantBuilder {
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *grantOpts) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"AuthKeys":      o.AuthKeys,
+		"Channels":      o.Channels,
+		"ChannelGroups": o.ChannelGroups,
+		"UUIDs":         o.UUIDs,
+		"Read":          o.Read,
+		"Write":         o.Write,
+		"Manage":        o.Manage,
+		"Delete":        o.Delete,
+		"Get":           o.Get,
+		"Update":        o.Update,
+		"Join":          o.Join,
+	}
+	if o.setTTL {
+		params["TTL"] = o.TTL
+	}
+	if o.Meta != nil {
+		params["Meta"] = fmt.Sprintf("%v", o.Meta)
+	}
+	return params
+}
+
 // Execute runs the Grant request.
 func (b *grantBuilder) Execute() (*GrantResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNAccessManagerGrant, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyGrantResponse, status, err

--- a/heartbeat_request.go
+++ b/heartbeat_request.go
@@ -60,8 +60,22 @@ func (b *heartbeatBuilder) ChannelGroups(cg []string) *heartbeatBuilder {
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *heartbeatOpts) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"Channels":      o.Channels,
+		"ChannelGroups": o.ChannelGroups,
+	}
+	if o.State != nil {
+		params["State"] = fmt.Sprintf("%v", o.State)
+	}
+	return params
+}
+
 // Execute runs the Heartbeat request
 func (b *heartbeatBuilder) Execute() (interface{}, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNHeartBeatOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return "", status, err

--- a/here_now_request.go
+++ b/here_now_request.go
@@ -97,8 +97,29 @@ func (b *hereNowBuilder) Transport(tr http.RoundTripper) *hereNowBuilder {
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *hereNowOpts) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"Channels":      o.Channels,
+		"ChannelGroups": o.ChannelGroups,
+		"Limit":         o.Limit,
+	}
+	if o.SetIncludeUUIDs {
+		params["IncludeUUIDs"] = o.IncludeUUIDs
+	}
+	if o.SetIncludeState {
+		params["IncludeState"] = o.IncludeState
+	}
+	if o.SetOffset {
+		params["Offset"] = o.Offset
+	}
+	return params
+}
+
 // Execute runs the HereNow request.
 func (b *hereNowBuilder) Execute() (*HereNowResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNHereNowOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyHereNowResponse, status, err

--- a/history_delete_request.go
+++ b/history_delete_request.go
@@ -63,8 +63,24 @@ func (b *historyDeleteBuilder) Transport(tr http.RoundTripper) *historyDeleteBui
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *historyDeleteOpts) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"Channel": o.Channel,
+	}
+	if o.SetStart {
+		params["Start"] = o.Start
+	}
+	if o.SetEnd {
+		params["End"] = o.End
+	}
+	return params
+}
+
 // Execute runs the DeleteMessages request.
 func (b *historyDeleteBuilder) Execute() (*HistoryDeleteResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNDeleteMessagesOperation, b.opts.GetLogParams(), true)
+
 	_, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyHistoryDeleteResp, status, err

--- a/leave_request.go
+++ b/leave_request.go
@@ -45,8 +45,18 @@ func (b *leaveBuilder) QueryParam(queryParam map[string]string) *leaveBuilder {
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *leaveOpts) GetLogParams() map[string]interface{} {
+	return map[string]interface{}{
+		"Channels":      o.Channels,
+		"ChannelGroups": o.ChannelGroups,
+	}
+}
+
 // Execute runs the Leave request.
 func (b *leaveBuilder) Execute() (StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNUnsubscribeOperation, b.opts.GetLogParams(), true)
+	
 	_, status, err := executeRequest(b.opts)
 	if err != nil {
 		return status, err

--- a/list_all_channel_group_request.go
+++ b/list_all_channel_group_request.go
@@ -48,9 +48,18 @@ func (b *allChannelGroupBuilder) QueryParam(queryParam map[string]string) *allCh
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *allChannelGroupOpts) GetLogParams() map[string]interface{} {
+	return map[string]interface{}{
+		"ChannelGroup": o.ChannelGroup,
+	}
+}
+
 // Execute runs the ListChannelsInChannelGroup request.
 func (b *allChannelGroupBuilder) Execute() (
 	*AllChannelGroupResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNChannelsForGroupOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyAllChannelGroupResponse, status, err

--- a/list_push_provisions_request.go
+++ b/list_push_provisions_request.go
@@ -74,9 +74,26 @@ func (b *listPushProvisionsRequestBuilder) QueryParam(queryParam map[string]stri
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *listPushProvisionsRequestOpts) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"PushType":        o.PushType,
+		"DeviceIDForPush": o.DeviceIDForPush,
+	}
+	if o.Topic != "" {
+		params["Topic"] = o.Topic
+	}
+	if o.Environment != "" {
+		params["Environment"] = o.Environment
+	}
+	return params
+}
+
 // Execute runs the List Push Provisions request.
 func (b *listPushProvisionsRequestBuilder) Execute() (
 	*ListPushProvisionsRequestResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNPushNotificationsEnabledChannelsOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyListPushProvisionsRequestResponse, status, err

--- a/listener_manager.go
+++ b/listener_manager.go
@@ -60,16 +60,14 @@ func (m *ListenerManager) addListener(listener *Listener) {
 }
 
 func (m *ListenerManager) removeListener(listener *Listener) {
-	m.pubnub.Config.Log.Println("before removeListener")
+	m.pubnub.loggerManager.LogSimple(PNLogLevelDebug, "Removing listener", false)
 	m.Lock()
-	m.pubnub.Config.Log.Println("in removeListener lock")
 	delete(m.listeners, listener)
 	m.Unlock()
-	m.pubnub.Config.Log.Println("after removeListener")
 }
 
 func (m *ListenerManager) removeAllListeners() {
-	m.pubnub.Config.Log.Println("in removeAllListeners")
+	m.pubnub.loggerManager.LogSimple(PNLogLevelDebug, "Removing all listeners", false)
 	m.Lock()
 	lis := m.listeners
 	for l := range lis {
@@ -91,16 +89,14 @@ func (m *ListenerManager) copyListeners() map[*Listener]bool {
 func (m *ListenerManager) announceStatus(status *PNStatus) {
 	go func() {
 		lis := m.copyListeners()
-	AnnounceStatusLabel:
 		for l := range lis {
 			select {
 			case <-m.exitListener:
-				m.pubnub.Config.Log.Println("announceStatus exitListener")
-				break AnnounceStatusLabel
+				m.pubnub.loggerManager.LogSimple(PNLogLevelTrace, "announceStatus: exit listener", false)
+				return
 			case l.Status <- status:
 			}
 		}
-		m.pubnub.Config.Log.Println("announceStatus exit")
 	}()
 }
 
@@ -111,7 +107,7 @@ func (m *ListenerManager) announceMessage(message *PNMessage) {
 		for l := range lis {
 			select {
 			case <-m.exitListenerAnnounce:
-				m.pubnub.Config.Log.Println("announceMessage exitListenerAnnounce")
+				m.pubnub.loggerManager.LogSimple(PNLogLevelTrace, "announceMessage: exit listener", false)
 				break AnnounceMessageLabel
 			case l.Message <- message:
 			}
@@ -128,7 +124,7 @@ func (m *ListenerManager) announceSignal(message *PNMessage) {
 		for l := range lis {
 			select {
 			case <-m.exitListener:
-				m.pubnub.Config.Log.Println("announceSignal exitListener")
+				m.pubnub.loggerManager.LogSimple(PNLogLevelTrace, "announceSignal: exit listener", false)
 				break AnnounceSignalLabel
 
 			case l.Signal <- message:
@@ -145,11 +141,11 @@ func (m *ListenerManager) announceUUIDEvent(message *PNUUIDEvent) {
 		for l := range lis {
 			select {
 			case <-m.exitListener:
-				m.pubnub.Config.Log.Println("announceUUIDEvent exitListener")
+				m.pubnub.loggerManager.LogSimple(PNLogLevelTrace, "announceUUIDEvent: exit listener", false)
 				break AnnounceUUIDEventLabel
 
 			case l.UUIDEvent <- message:
-				m.pubnub.Config.Log.Println("l.UUIDEvent", message)
+				m.pubnub.loggerManager.LogSimple(PNLogLevelTrace, "announceUUIDEvent: message sent", false)
 			}
 		}
 	}()
@@ -161,14 +157,13 @@ func (m *ListenerManager) announceChannelEvent(message *PNChannelEvent) {
 
 	AnnounceChannelEventLabel:
 		for l := range lis {
-			m.pubnub.Config.Log.Println("l.ChannelEvent", l)
 			select {
 			case <-m.exitListener:
-				m.pubnub.Config.Log.Println("announceChannelEvent exitListener")
+				m.pubnub.loggerManager.LogSimple(PNLogLevelTrace, "announceChannelEvent: exit listener", false)
 				break AnnounceChannelEventLabel
 
 			case l.ChannelEvent <- message:
-				m.pubnub.Config.Log.Println("l.ChannelEvent", message)
+				m.pubnub.loggerManager.LogSimple(PNLogLevelTrace, "announceChannelEvent: message sent", false)
 			}
 		}
 	}()
@@ -182,11 +177,11 @@ func (m *ListenerManager) announceMembershipEvent(message *PNMembershipEvent) {
 		for l := range lis {
 			select {
 			case <-m.exitListener:
-				m.pubnub.Config.Log.Println("announceMembershipEvent exitListener")
+				m.pubnub.loggerManager.LogSimple(PNLogLevelTrace, "announceMembershipEvent: exit listener", false)
 				break AnnounceMembershipEvent
 
 			case l.MembershipEvent <- message:
-				m.pubnub.Config.Log.Println("l.MembershipEvent", message)
+				m.pubnub.loggerManager.LogSimple(PNLogLevelTrace, "announceMembershipEvent: message sent", false)
 			}
 		}
 	}()
@@ -200,11 +195,11 @@ func (m *ListenerManager) announceMessageActionsEvent(message *PNMessageActionsE
 		for l := range lis {
 			select {
 			case <-m.exitListener:
-				m.pubnub.Config.Log.Println("announceMessageActionsEvent exitListener")
+				m.pubnub.loggerManager.LogSimple(PNLogLevelTrace, "announceMessageActionsEvent: exit listener", false)
 				break AnnounceMessageActionsEvent
 
 			case l.MessageActionsEvent <- message:
-				m.pubnub.Config.Log.Println("l.MessageActionsEvent", message)
+				m.pubnub.loggerManager.LogSimple(PNLogLevelTrace, "announceMessageActionsEvent: message sent", false)
 			}
 		}
 	}()
@@ -218,7 +213,7 @@ func (m *ListenerManager) announcePresence(presence *PNPresence) {
 		for l := range lis {
 			select {
 			case <-m.exitListener:
-				m.pubnub.Config.Log.Println("announcePresence exitListener")
+				m.pubnub.loggerManager.LogSimple(PNLogLevelTrace, "announcePresence: exit listener", false)
 				break AnnouncePresenceLabel
 
 			case l.Presence <- presence:
@@ -235,7 +230,7 @@ func (m *ListenerManager) announceFile(file *PNFilesEvent) {
 		for l := range lis {
 			select {
 			case <-m.exitListener:
-				m.pubnub.Config.Log.Println("announceFile exitListener")
+				m.pubnub.loggerManager.LogSimple(PNLogLevelTrace, "announceFile: exit listener", false)
 				break AnnounceFileLabel
 
 			case l.File <- file:

--- a/logger.go
+++ b/logger.go
@@ -70,12 +70,6 @@ type ErrorLogMessage struct {
 	Operation OperationType
 }
 
-// ConfigLogMessage contains PubNub configuration details.
-type ConfigLogMessage struct {
-	BaseLogMessage
-	ConfigData map[string]interface{}
-}
-
 // UserInputLogMessage contains API call parameters.
 type UserInputLogMessage struct {
 	BaseLogMessage
@@ -114,12 +108,6 @@ func (msg ErrorLogMessage) String() string {
 		formatLogBase(msg), msg.ErrorName, msg.Error)
 }
 
-// String implements fmt.Stringer for ConfigLogMessage
-func (msg ConfigLogMessage) String() string {
-	return fmt.Sprintf("%s PubNub Create with configuration:\n%s",
-		formatLogBase(msg), formatConfigMap(msg.ConfigData))
-}
-
 // String implements fmt.Stringer for UserInputLogMessage
 func (msg UserInputLogMessage) String() string {
 	return fmt.Sprintf("%s %s with parameters:\n%s",
@@ -138,24 +126,6 @@ func formatLogBase(logMsg LogMessage) string {
 	}
 
 	return base
-}
-
-// formatConfigMap formats configuration data as a readable string
-func formatConfigMap(config map[string]interface{}) string {
-	if len(config) == 0 {
-		return "  (empty)"
-	}
-
-	var lines []string
-	for key, value := range config {
-		// Mask sensitive fields
-		if key == "SecretKey" || key == "CipherKey" {
-			lines = append(lines, fmt.Sprintf("  %-30s: %s", key, "****"))
-		} else {
-			lines = append(lines, fmt.Sprintf("  %-30s: %v", key, value))
-		}
-	}
-	return strings.Join(lines, "\n")
 }
 
 // formatParamsMap formats user parameters as a readable string
@@ -186,7 +156,6 @@ func formatParamsMap(params map[string]interface{}) string {
 //   - NetworkRequestLogMessage: HTTP request details
 //   - NetworkResponseLogMessage: HTTP response details
 //   - ErrorLogMessage: Error information with context
-//   - ConfigLogMessage: PubNub configuration
 //   - UserInputLogMessage: API call parameters
 //
 // Custom loggers can handle specific types using type switches, or use only

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,263 @@
+package pubnub
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ============================================================================
+// Log Message Interface and Types
+// ============================================================================
+
+// LogMessage is the interface for all log messages.
+// All log message types implement this interface to provide access to common fields.
+type LogMessage interface {
+	GetTimestamp() time.Time
+	GetInstanceID() string
+	GetLogLevel() PNLogLevel
+	GetMessage() string
+	GetCallsite() string
+}
+
+// BaseLogMessage contains common fields for all log messages.
+// All specific message types embed this struct.
+type BaseLogMessage struct {
+	Timestamp  time.Time
+	InstanceID string
+	LogLevel   PNLogLevel
+	Message    string
+	Callsite   string
+}
+
+// Interface method implementations for BaseLogMessage
+func (b BaseLogMessage) GetTimestamp() time.Time { return b.Timestamp }
+func (b BaseLogMessage) GetInstanceID() string   { return b.InstanceID }
+func (b BaseLogMessage) GetLogLevel() PNLogLevel { return b.LogLevel }
+func (b BaseLogMessage) GetMessage() string      { return b.Message }
+func (b BaseLogMessage) GetCallsite() string     { return b.Callsite }
+
+// SimpleLogMessage is used for general purpose logging.
+type SimpleLogMessage struct {
+	BaseLogMessage
+}
+
+// NetworkRequestLogMessage contains HTTP request details.
+type NetworkRequestLogMessage struct {
+	BaseLogMessage
+	Method  string
+	URL     string
+	Headers map[string]string
+	Body    string
+}
+
+// NetworkResponseLogMessage contains HTTP response details.
+type NetworkResponseLogMessage struct {
+	BaseLogMessage
+	StatusCode int
+	URL        string
+	Body       string
+}
+
+// ErrorLogMessage contains error information with context.
+type ErrorLogMessage struct {
+	BaseLogMessage
+	Error     error
+	ErrorName string
+	Operation OperationType
+}
+
+// ConfigLogMessage contains PubNub configuration details.
+type ConfigLogMessage struct {
+	BaseLogMessage
+	ConfigData map[string]interface{}
+}
+
+// UserInputLogMessage contains API call parameters.
+type UserInputLogMessage struct {
+	BaseLogMessage
+	Operation  OperationType
+	Parameters map[string]interface{}
+}
+
+// ============================================================================
+// Log Message Formatting (String methods)
+// ============================================================================
+
+// String implements fmt.Stringer for SimpleLogMessage
+func (msg SimpleLogMessage) String() string {
+	return fmt.Sprintf("%s %s", formatLogBase(msg), msg.Message)
+}
+
+// String implements fmt.Stringer for NetworkRequestLogMessage
+func (msg NetworkRequestLogMessage) String() string {
+	return fmt.Sprintf("%s Sending HTTP request %s %s with headers: %v body: %s",
+		formatLogBase(msg), msg.Method, msg.URL, msg.Headers, msg.Body)
+}
+
+// String implements fmt.Stringer for NetworkResponseLogMessage
+func (msg NetworkResponseLogMessage) String() string {
+	return fmt.Sprintf("%s Received response with %d content %s for request url %s",
+		formatLogBase(msg), msg.StatusCode, msg.Body, msg.URL)
+}
+
+// String implements fmt.Stringer for ErrorLogMessage
+func (msg ErrorLogMessage) String() string {
+	if msg.Operation != 0 {
+		return fmt.Sprintf("%s Error %s in %s: %v",
+			formatLogBase(msg), msg.ErrorName, msg.Operation.String(), msg.Error)
+	}
+	return fmt.Sprintf("%s Error %s: %v",
+		formatLogBase(msg), msg.ErrorName, msg.Error)
+}
+
+// String implements fmt.Stringer for ConfigLogMessage
+func (msg ConfigLogMessage) String() string {
+	return fmt.Sprintf("%s PubNub Create with configuration:\n%s",
+		formatLogBase(msg), formatConfigMap(msg.ConfigData))
+}
+
+// String implements fmt.Stringer for UserInputLogMessage
+func (msg UserInputLogMessage) String() string {
+	return fmt.Sprintf("%s %s with parameters:\n%s",
+		formatLogBase(msg), msg.Operation.String(), formatParamsMap(msg.Parameters))
+}
+
+// formatLogBase creates the common prefix for all log messages
+func formatLogBase(logMsg LogMessage) string {
+	base := fmt.Sprintf("%s PubNub-%s %s",
+		logMsg.GetTimestamp().Format("02/01/2006 15:04:05.000"),
+		logMsg.GetInstanceID(),
+		logMsg.GetLogLevel().String())
+
+	if callsite := logMsg.GetCallsite(); callsite != "" {
+		base = fmt.Sprintf("%s %s", base, callsite)
+	}
+
+	return base
+}
+
+// formatConfigMap formats configuration data as a readable string
+func formatConfigMap(config map[string]interface{}) string {
+	if len(config) == 0 {
+		return "  (empty)"
+	}
+
+	var lines []string
+	for key, value := range config {
+		// Mask sensitive fields
+		if key == "SecretKey" || key == "CipherKey" {
+			lines = append(lines, fmt.Sprintf("  %-30s: %s", key, "****"))
+		} else {
+			lines = append(lines, fmt.Sprintf("  %-30s: %v", key, value))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// formatParamsMap formats user parameters as a readable string
+func formatParamsMap(params map[string]interface{}) string {
+	if len(params) == 0 {
+		return "  (none)"
+	}
+
+	var lines []string
+	for key, value := range params {
+		lines = append(lines, fmt.Sprintf("  %s: %v", key, value))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// ============================================================================
+// Logger Interface
+// ============================================================================
+
+// PNLogger is the interface for custom logger implementations.
+// Users can implement this interface to provide their own logging mechanism.
+//
+// The Log method receives different LogMessage implementations depending on
+// the logging context. All messages implement the LogMessage interface.
+//
+// Available message types:
+//   - SimpleLogMessage: General purpose logs
+//   - NetworkRequestLogMessage: HTTP request details
+//   - NetworkResponseLogMessage: HTTP response details
+//   - ErrorLogMessage: Error information with context
+//   - ConfigLogMessage: PubNub configuration
+//   - UserInputLogMessage: API call parameters
+//
+// Custom loggers can handle specific types using type switches, or use only
+// the String() method or interface methods for generic handling.
+// See DefaultLogger for a reference implementation.
+type PNLogger interface {
+	// Log outputs a log message
+	Log(logMsg LogMessage)
+	// GetMinLogLevel returns the minimum log level for this logger
+	GetMinLogLevel() PNLogLevel
+}
+
+// Compile-time check to ensure DefaultLogger implements PNLogger
+var _ PNLogger = (*DefaultLogger)(nil)
+
+// ============================================================================
+// Default Logger Implementation
+// ============================================================================
+
+// DefaultLogger is the default console logger implementation.
+// It outputs formatted log messages to the specified writer (typically os.Stdout).
+// It serves as a reference implementation for custom loggers.
+type DefaultLogger struct {
+	minLogLevel PNLogLevel
+	output      io.Writer
+	mu          sync.Mutex
+}
+
+// NewDefaultLogger creates a new default console logger that writes to os.Stdout.
+// minLogLevel: the minimum log level to output
+func NewDefaultLogger(minLogLevel PNLogLevel) *DefaultLogger {
+	return &DefaultLogger{
+		minLogLevel: minLogLevel,
+		output:      os.Stdout,
+	}
+}
+
+// NewDefaultLoggerWithWriter creates a new default logger with a custom output writer.
+// This is useful for testing or redirecting logs to a file.
+// minLogLevel: the minimum log level to output
+// writer: the destination for log output
+func NewDefaultLoggerWithWriter(minLogLevel PNLogLevel, writer io.Writer) *DefaultLogger {
+	return &DefaultLogger{
+		minLogLevel: minLogLevel,
+		output:      writer,
+	}
+}
+
+// Log implements PNLogger interface.
+// It outputs the log message using its String() method if the log level is sufficient.
+func (dl *DefaultLogger) Log(logMsg LogMessage) {
+	if !dl.shouldLog(logMsg.GetLogLevel()) {
+		return
+	}
+
+	dl.mu.Lock()
+	defer dl.mu.Unlock()
+
+	// String() method is called automatically
+	fmt.Fprintln(dl.output, logMsg)
+}
+
+// GetMinLogLevel returns the minimum log level for this logger
+func (dl *DefaultLogger) GetMinLogLevel() PNLogLevel {
+	return dl.minLogLevel
+}
+
+// shouldLog checks if a message at the given level should be logged
+func (dl *DefaultLogger) shouldLog(level PNLogLevel) bool {
+	if dl.minLogLevel == PNLogLevelNone {
+		return false
+	}
+	return level >= dl.minLogLevel
+}

--- a/logger_manager.go
+++ b/logger_manager.go
@@ -149,21 +149,6 @@ func (lm *loggerManager) LogError(err error, errorName string, operation Operati
 	})
 }
 
-// LogConfig logs PubNub configuration.
-// includeCallsite: if true, captures the file and line number of the caller
-func (lm *loggerManager) LogConfig(level PNLogLevel, configData map[string]interface{}, includeCallsite bool) {
-	lm.log(ConfigLogMessage{
-		BaseLogMessage: BaseLogMessage{
-			Timestamp:  time.Now(),
-			InstanceID: lm.instanceID,
-			LogLevel:   level,
-			Message:    "Configuration",
-			Callsite:   lm.captureCallsite(includeCallsite, 2),
-		},
-		ConfigData: configData,
-	})
-}
-
 // LogUserInput logs user-provided API parameters.
 // includeCallsite: if true, captures the file and line number of the caller
 func (lm *loggerManager) LogUserInput(level PNLogLevel, operation OperationType, parameters map[string]interface{}, includeCallsite bool) {

--- a/logger_manager.go
+++ b/logger_manager.go
@@ -1,0 +1,181 @@
+package pubnub
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"time"
+)
+
+// ============================================================================
+// Logger Manager (Internal)
+// ============================================================================
+
+// loggerManager manages multiple loggers and provides convenient logging methods.
+// This is an internal type used by the PubNub instance.
+type loggerManager struct {
+	loggers    []PNLogger
+	instanceID string
+	mu         sync.RWMutex
+}
+
+// newLoggerManager creates a new logger manager.
+// instanceID: unique identifier for the PubNub instance
+// loggers: slice of loggers to use (can be empty)
+func newLoggerManager(instanceID string, loggers []PNLogger) *loggerManager {
+	return &loggerManager{
+		instanceID: instanceID,
+		loggers:    loggers,
+	}
+}
+
+// AddLogger adds a logger to the manager.
+func (lm *loggerManager) AddLogger(logger PNLogger) {
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
+	lm.loggers = append(lm.loggers, logger)
+}
+
+// RemoveAllLoggers removes all loggers from the manager.
+func (lm *loggerManager) RemoveAllLoggers() {
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
+	lm.loggers = nil
+}
+
+// log dispatches a log message to all registered loggers.
+// It checks each logger's minimum log level before dispatching.
+func (lm *loggerManager) log(logMsg LogMessage) {
+	lm.mu.RLock()
+	defer lm.mu.RUnlock()
+
+	if len(lm.loggers) == 0 {
+		return
+	}
+
+	level := logMsg.GetLogLevel()
+	for _, logger := range lm.loggers {
+		if level >= logger.GetMinLogLevel() {
+			logger.Log(logMsg)
+		}
+	}
+}
+
+// captureCallsite captures the caller's file and line number if requested.
+// skip: number of stack frames to skip (typically 1 to skip the logging method itself)
+// Returns formatted callsite string like "filename.go:123" or empty string if not captured.
+func (lm *loggerManager) captureCallsite(includeCallsite bool, skip int) string {
+	if !includeCallsite {
+		return ""
+	}
+	if _, file, line, ok := runtime.Caller(skip); ok {
+		return fmt.Sprintf("%s:%d", filepath.Base(file), line)
+	}
+	return ""
+}
+
+// ============================================================================
+// Simple Logging Method
+// ============================================================================
+
+// LogSimple logs a simple text message at the specified level.
+// includeCallsite: if true, captures the file and line number of the caller
+func (lm *loggerManager) LogSimple(level PNLogLevel, message string, includeCallsite bool) {
+	lm.log(SimpleLogMessage{
+		BaseLogMessage: BaseLogMessage{
+			Timestamp:  time.Now(),
+			InstanceID: lm.instanceID,
+			LogLevel:   level,
+			Message:    message,
+			Callsite:   lm.captureCallsite(includeCallsite, 2),
+		},
+	})
+}
+
+// ============================================================================
+// Specialized Logging Methods
+// ============================================================================
+
+// LogNetworkRequest logs an HTTP request.
+// includeCallsite: if true, captures the file and line number of the caller
+func (lm *loggerManager) LogNetworkRequest(level PNLogLevel, method, url string, headers map[string]string, body string, includeCallsite bool) {
+	lm.log(NetworkRequestLogMessage{
+		BaseLogMessage: BaseLogMessage{
+			Timestamp:  time.Now(),
+			InstanceID: lm.instanceID,
+			LogLevel:   level,
+			Message:    "HTTP Request",
+			Callsite:   lm.captureCallsite(includeCallsite, 2),
+		},
+		Method:  method,
+		URL:     url,
+		Headers: headers,
+		Body:    body,
+	})
+}
+
+// LogNetworkResponse logs an HTTP response.
+// includeCallsite: if true, captures the file and line number of the caller
+func (lm *loggerManager) LogNetworkResponse(level PNLogLevel, statusCode int, url, body string, includeCallsite bool) {
+	lm.log(NetworkResponseLogMessage{
+		BaseLogMessage: BaseLogMessage{
+			Timestamp:  time.Now(),
+			InstanceID: lm.instanceID,
+			LogLevel:   level,
+			Message:    "HTTP Response",
+			Callsite:   lm.captureCallsite(includeCallsite, 2),
+		},
+		StatusCode: statusCode,
+		URL:        url,
+		Body:       body,
+	})
+}
+
+// LogError logs an error with context.
+// includeCallsite: if true, captures the file and line number of the caller
+func (lm *loggerManager) LogError(err error, errorName string, operation OperationType, includeCallsite bool) {
+	lm.log(ErrorLogMessage{
+		BaseLogMessage: BaseLogMessage{
+			Timestamp:  time.Now(),
+			InstanceID: lm.instanceID,
+			LogLevel:   PNLogLevelError,
+			Message:    "Operation failed",
+			Callsite:   lm.captureCallsite(includeCallsite, 2),
+		},
+		Error:     err,
+		ErrorName: errorName,
+		Operation: operation,
+	})
+}
+
+// LogConfig logs PubNub configuration.
+// includeCallsite: if true, captures the file and line number of the caller
+func (lm *loggerManager) LogConfig(level PNLogLevel, configData map[string]interface{}, includeCallsite bool) {
+	lm.log(ConfigLogMessage{
+		BaseLogMessage: BaseLogMessage{
+			Timestamp:  time.Now(),
+			InstanceID: lm.instanceID,
+			LogLevel:   level,
+			Message:    "Configuration",
+			Callsite:   lm.captureCallsite(includeCallsite, 2),
+		},
+		ConfigData: configData,
+	})
+}
+
+// LogUserInput logs user-provided API parameters.
+// includeCallsite: if true, captures the file and line number of the caller
+func (lm *loggerManager) LogUserInput(level PNLogLevel, operation OperationType, parameters map[string]interface{}, includeCallsite bool) {
+	lm.log(UserInputLogMessage{
+		BaseLogMessage: BaseLogMessage{
+			Timestamp:  time.Now(),
+			InstanceID: lm.instanceID,
+			LogLevel:   level,
+			Message:    "API call",
+			Callsite:   lm.captureCallsite(includeCallsite, 2),
+		},
+		Operation:  operation,
+		Parameters: parameters,
+	})
+}

--- a/logger_manager.go
+++ b/logger_manager.go
@@ -37,6 +37,22 @@ func (lm *loggerManager) AddLogger(logger PNLogger) {
 	lm.loggers = append(lm.loggers, logger)
 }
 
+// RemoveLogger removes a specific logger from the manager.
+// Returns true if the logger was found and removed, false otherwise.
+func (lm *loggerManager) RemoveLogger(logger PNLogger) bool {
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
+
+	for i, l := range lm.loggers {
+		if l == logger {
+			// Remove logger by slicing around it
+			lm.loggers = append(lm.loggers[:i], lm.loggers[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
 // RemoveAllLoggers removes all loggers from the manager.
 func (lm *loggerManager) RemoveAllLoggers() {
 	lm.mu.Lock()

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,472 @@
+package pubnub
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ============================================================================
+// Test Logger Implementation
+// ============================================================================
+
+type testLogger struct {
+	logs     []LogMessage
+	minLevel PNLogLevel
+}
+
+func (t *testLogger) Log(logMsg LogMessage) {
+	t.logs = append(t.logs, logMsg)
+}
+
+func (t *testLogger) GetMinLogLevel() PNLogLevel {
+	return t.minLevel
+}
+
+func (t *testLogger) reset() {
+	t.logs = []LogMessage{}
+}
+
+func (t *testLogger) count() int {
+	return len(t.logs)
+}
+
+func (t *testLogger) getLastLog() LogMessage {
+	if len(t.logs) == 0 {
+		return nil
+	}
+	return t.logs[len(t.logs)-1]
+}
+
+// ============================================================================
+// LoggerManager Tests
+// ============================================================================
+
+func TestLoggerManager_AddLogger(t *testing.T) {
+	mgr := newLoggerManager("test-instance", []PNLogger{})
+	logger1 := &testLogger{minLevel: PNLogLevelInfo}
+	logger2 := &testLogger{minLevel: PNLogLevelDebug}
+
+	mgr.AddLogger(logger1)
+	mgr.AddLogger(logger2)
+
+	mgr.mu.RLock()
+	loggerCount := len(mgr.loggers)
+	mgr.mu.RUnlock()
+
+	if loggerCount != 2 {
+		t.Errorf("Expected 2 loggers, got %d", loggerCount)
+	}
+}
+
+func TestLoggerManager_RemoveAllLoggers(t *testing.T) {
+	logger1 := &testLogger{minLevel: PNLogLevelInfo}
+	logger2 := &testLogger{minLevel: PNLogLevelDebug}
+	mgr := newLoggerManager("test-instance", []PNLogger{logger1, logger2})
+
+	mgr.RemoveAllLoggers()
+
+	mgr.mu.RLock()
+	loggerCount := len(mgr.loggers)
+	mgr.mu.RUnlock()
+
+	if loggerCount != 0 {
+		t.Errorf("Expected 0 loggers after removal, got %d", loggerCount)
+	}
+}
+
+func TestLoggerManager_LogSimple(t *testing.T) {
+	logger := &testLogger{minLevel: PNLogLevelInfo}
+	mgr := newLoggerManager("test-instance", []PNLogger{logger})
+
+	mgr.LogSimple(PNLogLevelInfo, "test message", false)
+
+	if logger.count() != 1 {
+		t.Errorf("Expected 1 log, got %d", logger.count())
+	}
+
+	msg := logger.getLastLog()
+	if msg == nil {
+		t.Fatal("No log message received")
+	}
+
+	if msg.GetMessage() != "test message" {
+		t.Errorf("Expected 'test message', got '%s'", msg.GetMessage())
+	}
+
+	if msg.GetLogLevel() != PNLogLevelInfo {
+		t.Errorf("Expected PNLogLevelInfo, got %v", msg.GetLogLevel())
+	}
+}
+
+func TestLoggerManager_LogSimpleWithCallsite(t *testing.T) {
+	logger := &testLogger{minLevel: PNLogLevelInfo}
+	mgr := newLoggerManager("test-instance", []PNLogger{logger})
+
+	mgr.LogSimple(PNLogLevelInfo, "test message", true)
+
+	if logger.count() != 1 {
+		t.Errorf("Expected 1 log, got %d", logger.count())
+	}
+
+	msg := logger.getLastLog()
+	if msg == nil {
+		t.Fatal("No log message received")
+	}
+
+	if msg.GetCallsite() == "" {
+		t.Error("Expected callsite to be set")
+	}
+
+	if !strings.Contains(msg.GetCallsite(), "logger_test.go") {
+		t.Errorf("Expected callsite to contain 'logger_test.go', got '%s'", msg.GetCallsite())
+	}
+}
+
+func TestLoggerManager_LogError(t *testing.T) {
+	logger := &testLogger{minLevel: PNLogLevelError}
+	mgr := newLoggerManager("test-instance", []PNLogger{logger})
+
+	testErr := errors.New("test error")
+	mgr.LogError(testErr, "TestError", PNPublishOperation, false)
+
+	if logger.count() != 1 {
+		t.Errorf("Expected 1 log, got %d", logger.count())
+	}
+
+	msg := logger.getLastLog()
+	if msg == nil {
+		t.Fatal("No log message received")
+	}
+
+	errorMsg, ok := msg.(ErrorLogMessage)
+	if !ok {
+		t.Fatal("Expected ErrorLogMessage type")
+	}
+
+	if errorMsg.Error != testErr {
+		t.Errorf("Expected error to be %v, got %v", testErr, errorMsg.Error)
+	}
+
+	if errorMsg.ErrorName != "TestError" {
+		t.Errorf("Expected ErrorName 'TestError', got '%s'", errorMsg.ErrorName)
+	}
+
+	if errorMsg.Operation != PNPublishOperation {
+		t.Errorf("Expected PNPublishOperation, got %v", errorMsg.Operation)
+	}
+}
+
+func TestLoggerManager_LogUserInput(t *testing.T) {
+	logger := &testLogger{minLevel: PNLogLevelDebug}
+	mgr := newLoggerManager("test-instance", []PNLogger{logger})
+
+	params := map[string]interface{}{
+		"Channel": "test-channel",
+		"Message": "test-message",
+	}
+
+	mgr.LogUserInput(PNLogLevelDebug, PNPublishOperation, params, false)
+
+	if logger.count() != 1 {
+		t.Errorf("Expected 1 log, got %d", logger.count())
+	}
+
+	msg := logger.getLastLog()
+	if msg == nil {
+		t.Fatal("No log message received")
+	}
+
+	userInputMsg, ok := msg.(UserInputLogMessage)
+	if !ok {
+		t.Fatal("Expected UserInputLogMessage type")
+	}
+
+	if userInputMsg.Operation != PNPublishOperation {
+		t.Errorf("Expected PNPublishOperation, got %v", userInputMsg.Operation)
+	}
+
+	if userInputMsg.Parameters["Channel"] != "test-channel" {
+		t.Errorf("Expected Channel 'test-channel', got '%v'", userInputMsg.Parameters["Channel"])
+	}
+}
+
+func TestLoggerManager_MultipleLoggers(t *testing.T) {
+	logger1 := &testLogger{minLevel: PNLogLevelInfo}
+	logger2 := &testLogger{minLevel: PNLogLevelDebug}
+	mgr := newLoggerManager("test-instance", []PNLogger{logger1, logger2})
+
+	mgr.LogSimple(PNLogLevelInfo, "test message", false)
+
+	if logger1.count() != 1 {
+		t.Errorf("Logger1: Expected 1 log, got %d", logger1.count())
+	}
+
+	if logger2.count() != 1 {
+		t.Errorf("Logger2: Expected 1 log, got %d", logger2.count())
+	}
+}
+
+func TestLoggerManager_LogLevelFiltering(t *testing.T) {
+	logger := &testLogger{minLevel: PNLogLevelWarn}
+	mgr := newLoggerManager("test-instance", []PNLogger{logger})
+
+	// This should be logged (WARN >= WARN)
+	mgr.LogSimple(PNLogLevelWarn, "warning message", false)
+
+	// This should be logged (ERROR > WARN)
+	mgr.LogSimple(PNLogLevelError, "error message", false)
+
+	// This should NOT be logged (INFO < WARN)
+	mgr.LogSimple(PNLogLevelInfo, "info message", false)
+
+	// This should NOT be logged (DEBUG < WARN)
+	mgr.LogSimple(PNLogLevelDebug, "debug message", false)
+
+	if logger.count() != 2 {
+		t.Errorf("Expected 2 logs, got %d", logger.count())
+	}
+}
+
+// ============================================================================
+// DefaultLogger Tests
+// ============================================================================
+
+func TestDefaultLogger_Log(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewDefaultLoggerWithWriter(PNLogLevelInfo, &buf)
+
+	msg := SimpleLogMessage{
+		BaseLogMessage: BaseLogMessage{
+			Timestamp:  time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+			InstanceID: "test-id",
+			LogLevel:   PNLogLevelInfo,
+			Message:    "test message",
+		},
+	}
+
+	logger.Log(msg)
+
+	output := buf.String()
+
+	if !strings.Contains(output, "test message") {
+		t.Errorf("Expected output to contain 'test message', got: %s", output)
+	}
+
+	if !strings.Contains(output, "PubNub-test-id") {
+		t.Errorf("Expected output to contain 'PubNub-test-id', got: %s", output)
+	}
+
+	if !strings.Contains(output, "Info") {
+		t.Errorf("Expected output to contain 'Info', got: %s", output)
+	}
+}
+
+func TestDefaultLogger_GetMinLogLevel(t *testing.T) {
+	logger := NewDefaultLogger(PNLogLevelDebug)
+
+	if logger.GetMinLogLevel() != PNLogLevelDebug {
+		t.Errorf("Expected PNLogLevelDebug, got %v", logger.GetMinLogLevel())
+	}
+}
+
+// ============================================================================
+// Log Level Tests
+// ============================================================================
+
+func TestPNLogLevel_String(t *testing.T) {
+	tests := []struct {
+		level    PNLogLevel
+		expected string
+	}{
+		{PNLogLevelNone, "None"},
+		{PNLogLevelError, "Error"},
+		{PNLogLevelWarn, "Warn"},
+		{PNLogLevelInfo, "Info"},
+		{PNLogLevelDebug, "Debug"},
+		{PNLogLevelTrace, "Trace"},
+	}
+
+	for _, test := range tests {
+		if test.level.String() != test.expected {
+			t.Errorf("Expected '%s', got '%s'", test.expected, test.level.String())
+		}
+	}
+}
+
+// ============================================================================
+// Log Message Tests
+// ============================================================================
+
+func TestSimpleLogMessage_String(t *testing.T) {
+	msg := SimpleLogMessage{
+		BaseLogMessage: BaseLogMessage{
+			Timestamp:  time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+			InstanceID: "test-id",
+			LogLevel:   PNLogLevelInfo,
+			Message:    "test message",
+		},
+	}
+
+	str := msg.String()
+
+	if !strings.Contains(str, "test message") {
+		t.Errorf("Expected string to contain 'test message', got: %s", str)
+	}
+
+	if !strings.Contains(str, "PubNub-test-id") {
+		t.Errorf("Expected string to contain 'PubNub-test-id', got: %s", str)
+	}
+
+	if !strings.Contains(str, "Info") {
+		t.Errorf("Expected string to contain 'Info', got: %s", str)
+	}
+}
+
+func TestErrorLogMessage_String(t *testing.T) {
+	msg := ErrorLogMessage{
+		BaseLogMessage: BaseLogMessage{
+			Timestamp:  time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+			InstanceID: "test-id",
+			LogLevel:   PNLogLevelError,
+		},
+		Error:     errors.New("test error"),
+		ErrorName: "TestError",
+		Operation: PNPublishOperation,
+	}
+
+	str := msg.String()
+
+	if !strings.Contains(str, "TestError") {
+		t.Errorf("Expected string to contain 'TestError', got: %s", str)
+	}
+
+	if !strings.Contains(str, "test error") {
+		t.Errorf("Expected string to contain 'test error', got: %s", str)
+	}
+
+	if !strings.Contains(str, "Publish") {
+		t.Errorf("Expected string to contain 'Publish', got: %s", str)
+	}
+}
+
+func TestUserInputLogMessage_String(t *testing.T) {
+	msg := UserInputLogMessage{
+		BaseLogMessage: BaseLogMessage{
+			Timestamp:  time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+			InstanceID: "test-id",
+			LogLevel:   PNLogLevelDebug,
+		},
+		Operation: PNPublishOperation,
+		Parameters: map[string]interface{}{
+			"Channel": "test-channel",
+			"Message": "test-message",
+		},
+	}
+
+	str := msg.String()
+
+	if !strings.Contains(str, "Publish") {
+		t.Errorf("Expected string to contain 'Publish', got: %s", str)
+	}
+
+	if !strings.Contains(str, "Channel") {
+		t.Errorf("Expected string to contain 'Channel', got: %s", str)
+	}
+
+	if !strings.Contains(str, "test-channel") {
+		t.Errorf("Expected string to contain 'test-channel', got: %s", str)
+	}
+}
+
+func TestNetworkRequestLogMessage_String(t *testing.T) {
+	msg := NetworkRequestLogMessage{
+		BaseLogMessage: BaseLogMessage{
+			Timestamp:  time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+			InstanceID: "test-id",
+			LogLevel:   PNLogLevelDebug,
+		},
+		Method: "POST",
+		URL:    "https://ps.pndsn.com/publish",
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
+		Body: "test body",
+	}
+
+	str := msg.String()
+
+	if !strings.Contains(str, "POST") {
+		t.Errorf("Expected string to contain 'POST', got: %s", str)
+	}
+
+	if !strings.Contains(str, "https://ps.pndsn.com/publish") {
+		t.Errorf("Expected string to contain URL, got: %s", str)
+	}
+}
+
+func TestNetworkResponseLogMessage_String(t *testing.T) {
+	msg := NetworkResponseLogMessage{
+		BaseLogMessage: BaseLogMessage{
+			Timestamp:  time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+			InstanceID: "test-id",
+			LogLevel:   PNLogLevelDebug,
+		},
+		StatusCode: 200,
+		URL:        "https://ps.pndsn.com/publish",
+		Body:       "test response",
+	}
+
+	str := msg.String()
+
+	if !strings.Contains(str, "200") {
+		t.Errorf("Expected string to contain '200', got: %s", str)
+	}
+
+	if !strings.Contains(str, "https://ps.pndsn.com/publish") {
+		t.Errorf("Expected string to contain URL, got: %s", str)
+	}
+}
+
+// ============================================================================
+// Benchmark Tests
+// ============================================================================
+
+func BenchmarkLoggerManager_LogSimple(b *testing.B) {
+	logger := NewDefaultLogger(PNLogLevelInfo)
+	mgr := newLoggerManager("test-instance", []PNLogger{logger})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		mgr.LogSimple(PNLogLevelInfo, "benchmark test message", false)
+	}
+}
+
+func BenchmarkLoggerManager_LogError(b *testing.B) {
+	logger := NewDefaultLogger(PNLogLevelError)
+	mgr := newLoggerManager("test-instance", []PNLogger{logger})
+
+	testErr := errors.New("benchmark error")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		mgr.LogError(testErr, "BenchmarkError", PNPublishOperation, false)
+	}
+}
+
+func BenchmarkLoggerManager_LogUserInput(b *testing.B) {
+	logger := NewDefaultLogger(PNLogLevelDebug)
+	mgr := newLoggerManager("test-instance", []PNLogger{logger})
+
+	params := map[string]interface{}{
+		"Channel": "test-channel",
+		"Message": "test-message",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		mgr.LogUserInput(PNLogLevelDebug, PNPublishOperation, params, false)
+	}
+}

--- a/message_actions_add.go
+++ b/message_actions_add.go
@@ -70,8 +70,19 @@ func (b *addMessageActionsBuilder) Transport(tr http.RoundTripper) *addMessageAc
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *addMessageActionsOpts) GetLogParams() map[string]interface{} {
+	return map[string]interface{}{
+		"Channel":          o.Channel,
+		"MessageTimetoken": o.MessageTimetoken,
+		"Action":           fmt.Sprintf("%v", o.Action),
+	}
+}
+
 // Execute runs the addMessageActions request.
 func (b *addMessageActionsBuilder) Execute() (*PNAddMessageActionsResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNAddMessageActionsOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyPNAddMessageActionsResponse, status, err
@@ -117,7 +128,7 @@ func (o *addMessageActionsOpts) buildBody() ([]byte, error) {
 	jsonEncBytes, errEnc := json.Marshal(o.Action)
 
 	if errEnc != nil {
-		o.pubnub.Config.Log.Printf("ERROR: Serialization error: %s\n", errEnc.Error())
+		o.pubnub.loggerManager.LogError(errEnc, "AddMessageActionsSerializationFailed", PNAddMessageActionsOperation, true)
 		return []byte{}, errEnc
 	}
 	return jsonEncBytes, nil

--- a/message_actions_get.go
+++ b/message_actions_get.go
@@ -71,8 +71,25 @@ func (b *getMessageActionsBuilder) Transport(tr http.RoundTripper) *getMessageAc
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *getMessageActionsOpts) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"Channel": o.Channel,
+		"Limit":   o.Limit,
+	}
+	if o.Start != "" {
+		params["Start"] = o.Start
+	}
+	if o.End != "" {
+		params["End"] = o.End
+	}
+	return params
+}
+
 // Execute runs the getMessageActions request.
 func (b *getMessageActionsBuilder) Execute() (*PNGetMessageActionsResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNGetMessageActionsOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyPNGetMessageActionsResponse, status, err

--- a/message_actions_remove.go
+++ b/message_actions_remove.go
@@ -64,8 +64,19 @@ func (b *removeMessageActionsBuilder) Transport(tr http.RoundTripper) *removeMes
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *removeMessageActionsOpts) GetLogParams() map[string]interface{} {
+	return map[string]interface{}{
+		"Channel":          o.Channel,
+		"MessageTimetoken": o.MessageTimetoken,
+		"ActionTimetoken":  o.ActionTimetoken,
+	}
+}
+
 // Execute runs the removeMessageActions request.
 func (b *removeMessageActionsBuilder) Execute() (*PNRemoveMessageActionsResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNRemoveMessageActionsOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyPNRemoveMessageActionsResponse, status, err

--- a/objects_get_all_channel_metadata.go
+++ b/objects_get_all_channel_metadata.go
@@ -94,8 +94,32 @@ func (b *getAllChannelMetadataBuilder) Transport(tr http.RoundTripper) *getAllCh
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *getAllChannelMetadataOpts) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"Limit":   o.Limit,
+		"Include": o.Include,
+		"Count":   o.Count,
+	}
+	if o.Start != "" {
+		params["Start"] = o.Start
+	}
+	if o.End != "" {
+		params["End"] = o.End
+	}
+	if o.Filter != "" {
+		params["Filter"] = o.Filter
+	}
+	if len(o.Sort) > 0 {
+		params["Sort"] = o.Sort
+	}
+	return params
+}
+
 // Execute runs the getAllChannelMetadata request.
 func (b *getAllChannelMetadataBuilder) Execute() (*PNGetAllChannelMetadataResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNGetAllChannelMetadataOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyGetAllChannelMetadataResponse, status, err

--- a/objects_get_all_uuid_metadata.go
+++ b/objects_get_all_uuid_metadata.go
@@ -94,8 +94,32 @@ func (b *getAllUUIDMetadataBuilder) Transport(tr http.RoundTripper) *getAllUUIDM
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *getAllUUIDMetadataOpts) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"Limit":   o.Limit,
+		"Include": o.Include,
+		"Count":   o.Count,
+	}
+	if o.Start != "" {
+		params["Start"] = o.Start
+	}
+	if o.End != "" {
+		params["End"] = o.End
+	}
+	if o.Filter != "" {
+		params["Filter"] = o.Filter
+	}
+	if len(o.Sort) > 0 {
+		params["Sort"] = o.Sort
+	}
+	return params
+}
+
 // Execute runs the getAllUUIDMetadata request.
 func (b *getAllUUIDMetadataBuilder) Execute() (*PNGetAllUUIDMetadataResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNGetAllUUIDMetadataOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyPNGetAllUUIDMetadataResponse, status, err

--- a/objects_get_channel_members_v2.go
+++ b/objects_get_channel_members_v2.go
@@ -100,8 +100,33 @@ func (b *getChannelMembersBuilderV2) Transport(tr http.RoundTripper) *getChannel
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *getChannelMembersOptsV2) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"Channel": o.Channel,
+		"Limit":   o.Limit,
+		"Include": o.Include,
+		"Count":   o.Count,
+	}
+	if o.Start != "" {
+		params["Start"] = o.Start
+	}
+	if o.End != "" {
+		params["End"] = o.End
+	}
+	if o.Filter != "" {
+		params["Filter"] = o.Filter
+	}
+	if len(o.Sort) > 0 {
+		params["Sort"] = o.Sort
+	}
+	return params
+}
+
 // Execute runs the getChannelMembers request.
 func (b *getChannelMembersBuilderV2) Execute() (*PNGetChannelMembersResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNGetChannelMembersOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyGetChannelMembersResponse, status, err

--- a/objects_get_channel_metadata.go
+++ b/objects_get_channel_metadata.go
@@ -58,8 +58,19 @@ func (b *getChannelMetadataBuilder) Transport(tr http.RoundTripper) *getChannelM
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *getChannelMetadataOpts) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"Channel": o.Channel,
+		"Include": o.Include,
+	}
+	return params
+}
+
 // Execute runs the getChannelMetadata request.
 func (b *getChannelMetadataBuilder) Execute() (*PNGetChannelMetadataResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNGetChannelMetadataOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyPNGetChannelMetadataResponse, status, err

--- a/objects_get_memberships_v2.go
+++ b/objects_get_memberships_v2.go
@@ -100,12 +100,39 @@ func (b *getMembershipsBuilderV2) Transport(tr http.RoundTripper) *getMembership
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *getMembershipsOptsV2) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"Limit":   o.Limit,
+		"Include": o.Include,
+		"Count":   o.Count,
+	}
+	if o.UUID != "" {
+		params["UUID"] = o.UUID
+	}
+	if o.Start != "" {
+		params["Start"] = o.Start
+	}
+	if o.End != "" {
+		params["End"] = o.End
+	}
+	if o.Filter != "" {
+		params["Filter"] = o.Filter
+	}
+	if len(o.Sort) > 0 {
+		params["Sort"] = o.Sort
+	}
+	return params
+}
+
 // Execute runs the getMemberships request.
 func (b *getMembershipsBuilderV2) Execute() (*PNGetMembershipsResponse, StatusResponse, error) {
 	if len(b.opts.UUID) <= 0 {
 		b.opts.UUID = b.opts.pubnub.Config.UUID
 	}
 
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNGetMembershipsOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyGetMembershipsResponse, status, err

--- a/objects_get_uuid_metadata.go
+++ b/objects_get_uuid_metadata.go
@@ -58,12 +58,25 @@ func (b *getUUIDMetadataBuilder) Transport(tr http.RoundTripper) *getUUIDMetadat
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *getUUIDMetadataOpts) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"Include": o.Include,
+	}
+	if o.UUID != "" {
+		params["UUID"] = o.UUID
+	}
+	return params
+}
+
 // Execute runs the getUUIDMetadata request.
 func (b *getUUIDMetadataBuilder) Execute() (*PNGetUUIDMetadataResponse, StatusResponse, error) {
 	if len(b.opts.UUID) <= 0 {
 		b.opts.UUID = b.opts.pubnub.Config.UUID
 	}
 
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNGetUUIDMetadataOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyPNGetUUIDMetadataResponse, status, err

--- a/objects_manage_memberships_v2.go
+++ b/objects_manage_memberships_v2.go
@@ -109,12 +109,33 @@ func (b *manageMembershipsBuilderV2) Transport(tr http.RoundTripper) *manageMemb
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *manageMembershipsOptsV2) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"Limit":   o.Limit,
+		"Include": o.Include,
+		"Count":   o.Count,
+	}
+	if o.UUID != "" {
+		params["UUID"] = o.UUID
+	}
+	if len(o.MembershipsSet) > 0 {
+		params["MembershipsSet"] = fmt.Sprintf("(%d memberships)", len(o.MembershipsSet))
+	}
+	if len(o.MembershipsRemove) > 0 {
+		params["MembershipsRemove"] = fmt.Sprintf("(%d memberships)", len(o.MembershipsRemove))
+	}
+	return params
+}
+
 // Execute runs the manageMemberships request.
 func (b *manageMembershipsBuilderV2) Execute() (*PNManageMembershipsResponse, StatusResponse, error) {
 	if len(b.opts.UUID) <= 0 {
 		b.opts.UUID = b.opts.pubnub.Config.UUID
 	}
 
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNManageMembershipsOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyManageMembershipsResponse, status, err
@@ -205,7 +226,7 @@ func (o *manageMembershipsOptsV2) buildBody() ([]byte, error) {
 	jsonEncBytes, errEnc := json.Marshal(b)
 
 	if errEnc != nil {
-		o.pubnub.Config.Log.Printf("ERROR: Serialization error: %s\n", errEnc.Error())
+		o.pubnub.loggerManager.LogError(errEnc, "ManageMembershipsV2SerializationFailed", PNManageMembershipsOperation, true)
 		return []byte{}, errEnc
 	}
 	return jsonEncBytes, nil

--- a/objects_remove_channel_members.go
+++ b/objects_remove_channel_members.go
@@ -103,8 +103,24 @@ func (b *removeChannelMembersBuilder) Transport(tr http.RoundTripper) *removeCha
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *removeChannelMembersOpts) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"Channel": o.Channel,
+		"Limit":   o.Limit,
+		"Include": o.Include,
+		"Count":   o.Count,
+	}
+	if len(o.ChannelMembersRemove) > 0 {
+		params["ChannelMembersRemove"] = fmt.Sprintf("(%d members)", len(o.ChannelMembersRemove))
+	}
+	return params
+}
+
 // Execute runs the removeChannelMembers request.
 func (b *removeChannelMembersBuilder) Execute() (*PNRemoveChannelMembersResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNRemoveChannelMembersOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyRemoveChannelMembersResponse, status, err
@@ -201,7 +217,7 @@ func (o *removeChannelMembersOpts) buildBody() ([]byte, error) {
 	jsonEncBytes, errEnc := json.Marshal(b)
 
 	if errEnc != nil {
-		o.pubnub.Config.Log.Printf("ERROR: Serialization error: %s\n", errEnc.Error())
+		o.pubnub.loggerManager.LogError(errEnc, "RemoveChannelMembersSerializationFailed", PNRemoveChannelMembersOperation, true)
 		return []byte{}, errEnc
 	}
 	return jsonEncBytes, nil

--- a/objects_remove_channel_metadata.go
+++ b/objects_remove_channel_metadata.go
@@ -52,8 +52,17 @@ func (b *removeChannelMetadataBuilder) Transport(tr http.RoundTripper) *removeCh
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *removeChannelMetadataOpts) GetLogParams() map[string]interface{} {
+	return map[string]interface{}{
+		"Channel": o.Channel,
+	}
+}
+
 // Execute runs the removeChannelMetadata request.
 func (b *removeChannelMetadataBuilder) Execute() (*PNRemoveChannelMetadataResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNRemoveChannelMetadataOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyPNRemoveChannelMetadataResponse, status, err

--- a/objects_remove_uuid_metadata.go
+++ b/objects_remove_uuid_metadata.go
@@ -52,12 +52,23 @@ func (b *removeUUIDMetadataBuilder) Transport(tr http.RoundTripper) *removeUUIDM
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *removeUUIDMetadataOpts) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{}
+	if o.UUID != "" {
+		params["UUID"] = o.UUID
+	}
+	return params
+}
+
 // Execute runs the removeUUIDMetadata request.
 func (b *removeUUIDMetadataBuilder) Execute() (*PNRemoveUUIDMetadataResponse, StatusResponse, error) {
 	if len(b.opts.UUID) <= 0 {
 		b.opts.UUID = b.opts.pubnub.Config.UUID
 	}
 
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNRemoveUUIDMetadataOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyPNRemoveUUIDMetadataResponse, status, err

--- a/objects_set_channel_metadata.go
+++ b/objects_set_channel_metadata.go
@@ -106,8 +106,34 @@ func (b *setChannelMetadataBuilder) Transport(tr http.RoundTripper) *setChannelM
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *setChannelMetadataOpts) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"Channel": o.Channel,
+		"Include": o.Include,
+	}
+	if o.Name != "" {
+		params["Name"] = o.Name
+	}
+	if o.Description != "" {
+		params["Description"] = o.Description
+	}
+	if o.Status != "" {
+		params["Status"] = o.Status
+	}
+	if o.Type != "" {
+		params["Type"] = o.Type
+	}
+	if o.Custom != nil {
+		params["Custom"] = fmt.Sprintf("%v", o.Custom)
+	}
+	return params
+}
+
 // Execute runs the setChannelMetadata request.
 func (b *setChannelMetadataBuilder) Execute() (*PNSetChannelMetadataResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNSetChannelMetadataOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyPNSetChannelMetadataResponse, status, err
@@ -173,7 +199,7 @@ func (o *setChannelMetadataOpts) buildBody() ([]byte, error) {
 	jsonEncBytes, errEnc := json.Marshal(b)
 
 	if errEnc != nil {
-		o.pubnub.Config.Log.Printf("ERROR: Serialization error: %s\n", errEnc.Error())
+		o.pubnub.loggerManager.LogError(errEnc, "SetChannelMetadataSerializationFailed", PNSetChannelMetadataOperation, true)
 		return []byte{}, errEnc
 	}
 	return jsonEncBytes, nil

--- a/objects_set_uuid_metadata.go
+++ b/objects_set_uuid_metadata.go
@@ -120,11 +120,45 @@ func (b *setUUIDMetadataBuilder) Transport(tr http.RoundTripper) *setUUIDMetadat
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *setUUIDMetadataOpts) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"Include": o.Include,
+	}
+	if o.UUID != "" {
+		params["UUID"] = o.UUID
+	}
+	if o.Name != "" {
+		params["Name"] = o.Name
+	}
+	if o.ExternalID != "" {
+		params["ExternalID"] = o.ExternalID
+	}
+	if o.ProfileURL != "" {
+		params["ProfileURL"] = o.ProfileURL
+	}
+	if o.Email != "" {
+		params["Email"] = o.Email
+	}
+	if o.Status != "" {
+		params["Status"] = o.Status
+	}
+	if o.Type != "" {
+		params["Type"] = o.Type
+	}
+	if o.Custom != nil {
+		params["Custom"] = fmt.Sprintf("%v", o.Custom)
+	}
+	return params
+}
+
 // Execute runs the setUUIDMetadata request.
 func (b *setUUIDMetadataBuilder) Execute() (*PNSetUUIDMetadataResponse, StatusResponse, error) {
 	if len(b.opts.UUID) <= 0 {
 		b.opts.UUID = b.opts.pubnub.Config.UUID
 	}
+
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNSetUUIDMetadataOperation, b.opts.GetLogParams(), true)
 
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
@@ -192,7 +226,7 @@ func (o *setUUIDMetadataOpts) buildBody() ([]byte, error) {
 	jsonEncBytes, errEnc := json.Marshal(b)
 
 	if errEnc != nil {
-		o.pubnub.Config.Log.Printf("ERROR: Serialization error: %s\n", errEnc.Error())
+		o.pubnub.loggerManager.LogError(errEnc, "SetUUIDMetadataSerializationFailed", PNSetUUIDMetadataOperation, true)
 		return []byte{}, errEnc
 	}
 	return jsonEncBytes, nil

--- a/publish_request_test.go
+++ b/publish_request_test.go
@@ -506,7 +506,7 @@ func TestNewPublishResponse(t *testing.T) {
 	assert := assert.New(t)
 	jsonBytes := []byte(`s`)
 
-	_, _, err := newPublishResponse(jsonBytes, StatusResponse{})
+	_, _, err := newPublishResponse(jsonBytes, StatusResponse{}, nil)
 	assert.Equal("pubnub/parsing: Error unmarshalling response: {s}", err.Error())
 }
 
@@ -514,7 +514,7 @@ func TestNewPublishResponseTimestamp(t *testing.T) {
 	assert := assert.New(t)
 	jsonBytes := []byte(`[1, Sent, "a"]`)
 
-	_, _, err := newPublishResponse(jsonBytes, StatusResponse{})
+	_, _, err := newPublishResponse(jsonBytes, StatusResponse{}, nil)
 	assert.Equal("pubnub/parsing: Error unmarshalling response: {[1, Sent, \"a\"]}", err.Error())
 }
 
@@ -522,7 +522,7 @@ func TestNewPublishResponseTimestamp2(t *testing.T) {
 	assert := assert.New(t)
 	jsonBytes := []byte(`[1, "Sent", "a"]`)
 
-	_, _, err := newPublishResponse(jsonBytes, StatusResponse{})
+	_, _, err := newPublishResponse(jsonBytes, StatusResponse{}, nil)
 	assert.Contains(err.Error(), "parsing \"a\": invalid syntax")
 }
 

--- a/pubnub.go
+++ b/pubnub.go
@@ -96,7 +96,10 @@ func (pn *PubNub) getCryptoModule() crypto.CryptoModule {
 
 	if pn.Config != nil && pn.Config.CipherKey != "" {
 		pn.Config.CryptoModule, _ = crypto.NewLegacyCryptoModule(pn.Config.CipherKey, pn.Config.UseRandomInitializationVector)
-		pn.loggerManager.LogSimple(PNLogLevelDebug, fmt.Sprintf("Crypto Module re-initialized: type=LegacyCryptoModule, randomIV=%t (cipher key or IV flag changed)", pn.Config.UseRandomInitializationVector), false)
+		pn.loggerManager.LogSimple(PNLogLevelDebug, fmt.Sprintf(`Crypto Module re-initialized (cipher key or IV flag changed):
+			type: LegacyCryptoModule
+			cipherKey: ***
+			randomIV: %t`, pn.Config.UseRandomInitializationVector), false)
 		pn.previousCipherKey = pn.Config.CipherKey
 		pn.previousIvFlag = pn.Config.UseRandomInitializationVector
 		return pn.Config.CryptoModule
@@ -857,9 +860,13 @@ func NewPubNub(pnconf *Config) *PubNub {
 		if e != nil {
 			panic(e)
 		}
-		loggerMgr.LogSimple(PNLogLevelDebug, fmt.Sprintf("Crypto Module initialized: type=LegacyCryptoModule, randomIV=%t", pnconf.UseRandomInitializationVector), false)
+		loggerMgr.LogSimple(PNLogLevelDebug, fmt.Sprintf(`Crypto Module initialized:
+  type: LegacyCryptoModule
+  cipherKey: ***
+  randomIV: %t`, pnconf.UseRandomInitializationVector), false)
 	} else if pnconf.CryptoModule != nil {
-		loggerMgr.LogSimple(PNLogLevelDebug, "Crypto Module initialized: type=CustomCryptoModule", false)
+		loggerMgr.LogSimple(PNLogLevelDebug, `Crypto Module initialized:
+  type: CustomCryptoModule`, false)
 	}
 	pn.subscriptionManager = newSubscriptionManager(pn, ctx)
 	pn.heartbeatManager = newHeartbeatManager(pn, ctx)

--- a/pubnub.go
+++ b/pubnub.go
@@ -820,18 +820,18 @@ func NewPubNub(pnconf *Config) *PubNub {
 	} else {
 		// For backward compatibility, if old logger is provided, we bridge it to the new logger manager
 		// Use Warn level - minimal logging (warnings and errors only)
-		defaultLogger := NewDefaultLoggerWithWriter(PNLogLevelWarn, pnconf.Log.Writer())
+		defaultLogger := NewDefaultLoggerWithWriter(PNLogLevelDebug, pnconf.Log.Writer())
 		loggerMgr.AddLogger(defaultLogger)
 	}
-
-	// Log SDK initialization with masked config
-	loggerMgr.LogSimple(PNLogLevelInfo, fmt.Sprintf("PubNub Go SDK v%s initialized\nGo: %s %s/%s\n%s",
-		Version, runtime.Version(), runtime.GOOS, runtime.GOARCH, pnconf.GetLogString()), false)
 
 	// Log any validation warnings from config setup
 	for _, warning := range pnconf.validationWarnings {
 		loggerMgr.LogSimple(PNLogLevelWarn, fmt.Sprintf("Config validation: %s", warning), false)
 	}
+
+	// Log SDK initialization with masked config
+	loggerMgr.LogSimple(PNLogLevelInfo, fmt.Sprintf("PubNub Go SDK v%s initialized\nGo: %s %s/%s\n%s",
+		Version, runtime.Version(), runtime.GOOS, runtime.GOARCH, pnconf.GetLogString()), false)
 
 	pn := &PubNub{
 		Config:              pnconf,

--- a/pubnub.go
+++ b/pubnub.go
@@ -96,9 +96,16 @@ func (pn *PubNub) getCryptoModule() crypto.CryptoModule {
 
 	if pn.Config != nil && pn.Config.CipherKey != "" {
 		pn.Config.CryptoModule, _ = crypto.NewLegacyCryptoModule(pn.Config.CipherKey, pn.Config.UseRandomInitializationVector)
+		pn.loggerManager.LogSimple(PNLogLevelDebug, fmt.Sprintf("Crypto Module re-initialized: type=LegacyCryptoModule, randomIV=%t (cipher key or IV flag changed)", pn.Config.UseRandomInitializationVector), false)
+		pn.previousCipherKey = pn.Config.CipherKey
+		pn.previousIvFlag = pn.Config.UseRandomInitializationVector
 		return pn.Config.CryptoModule
 	} else if pn.Config != nil && pn.Config.CipherKey == "" {
+		if pn.Config.CryptoModule != nil {
+			pn.loggerManager.LogSimple(PNLogLevelDebug, "Crypto Module cleared (cipher key removed)", false)
+		}
 		pn.Config.CryptoModule = nil
+		pn.previousCipherKey = ""
 		return pn.Config.CryptoModule
 	}
 	return nil
@@ -850,6 +857,9 @@ func NewPubNub(pnconf *Config) *PubNub {
 		if e != nil {
 			panic(e)
 		}
+		loggerMgr.LogSimple(PNLogLevelDebug, fmt.Sprintf("Crypto Module initialized: type=LegacyCryptoModule, randomIV=%t", pnconf.UseRandomInitializationVector), false)
+	} else if pnconf.CryptoModule != nil {
+		loggerMgr.LogSimple(PNLogLevelDebug, "Crypto Module initialized: type=CustomCryptoModule", false)
 	}
 	pn.subscriptionManager = newSubscriptionManager(pn, ctx)
 	pn.heartbeatManager = newHeartbeatManager(pn, ctx)

--- a/pubnub.go
+++ b/pubnub.go
@@ -819,7 +819,7 @@ func NewPubNub(pnconf *Config) *PubNub {
 		pnconf.Log = log.New(io.Discard, "", log.Ldate|log.Ltime|log.Lshortfile)
 	} else {
 		// For backward compatibility, if old logger is provided, we bridge it to the new logger manager
-		// Use Warn level - minimal logging (warnings and errors only)
+		// Use Debug level to maintain backward compatibility with existing verbose logging behavior
 		defaultLogger := NewDefaultLoggerWithWriter(PNLogLevelDebug, pnconf.Log.Writer())
 		loggerMgr.AddLogger(defaultLogger)
 	}

--- a/pubnub.go
+++ b/pubnub.go
@@ -18,7 +18,7 @@ import (
 // Default constants
 const (
 	// Version :the version of the SDK
-	Version = "8.0.0"
+	Version = "8.1.0"
 	// MaxSequence for publish messages
 	MaxSequence = 65535
 )

--- a/remove_all_push_channels_request.go
+++ b/remove_all_push_channels_request.go
@@ -64,9 +64,26 @@ func (b *removeAllPushChannelsForDeviceBuilder) QueryParam(queryParam map[string
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *removeAllPushChannelsForDeviceOpts) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"PushType":        o.PushType,
+		"DeviceIDForPush": o.DeviceIDForPush,
+	}
+	if o.Topic != "" {
+		params["Topic"] = o.Topic
+	}
+	if o.Environment != "" {
+		params["Environment"] = o.Environment
+	}
+	return params
+}
+
 // Execute runs the RemoveAllPushNotifications request.
 func (b *removeAllPushChannelsForDeviceBuilder) Execute() (
 	*RemoveAllPushChannelsForDeviceResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNRemoveAllPushNotificationsOperation, b.opts.GetLogParams(), true)
+	
 	_, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyRemoveAllPushChannelsForDeviceResponse, status, err

--- a/remove_channel_channel_group_request.go
+++ b/remove_channel_channel_group_request.go
@@ -55,9 +55,19 @@ func (b *removeChannelFromChannelGroupBuilder) QueryParam(queryParam map[string]
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *removeChannelOpts) GetLogParams() map[string]interface{} {
+	return map[string]interface{}{
+		"Channels":     o.Channels,
+		"ChannelGroup": o.ChannelGroup,
+	}
+}
+
 // Execute runs RemoveChannelFromChannelGroup request
 func (b *removeChannelFromChannelGroupBuilder) Execute() (
 	*RemoveChannelFromChannelGroupResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNRemoveChannelFromChannelGroupOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyRemoveChannelFromChannelGroupResponse, status, err

--- a/remove_channels_from_push_request.go
+++ b/remove_channels_from_push_request.go
@@ -71,8 +71,26 @@ func (b *removeChannelsFromPushBuilder) Transport(tr http.RoundTripper) *removeC
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *removeChannelsFromPushOpts) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"Channels":        o.Channels,
+		"PushType":        o.PushType,
+		"DeviceIDForPush": o.DeviceIDForPush,
+	}
+	if o.Topic != "" {
+		params["Topic"] = o.Topic
+	}
+	if o.Environment != "" {
+		params["Environment"] = o.Environment
+	}
+	return params
+}
+
 // Execute runs the RemovePushNotificationsFromChannels request.
 func (b *removeChannelsFromPushBuilder) Execute() (*RemoveChannelsFromPushResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNRemovePushNotificationsFromChannelsOperation, b.opts.GetLogParams(), true)
+	
 	_, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyRemoveChannelsFromPushResponse, status, err

--- a/revoke_token.go
+++ b/revoke_token.go
@@ -45,8 +45,24 @@ func (b *revokeTokenBuilder) QueryParam(queryParam map[string]string) *revokeTok
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *revokeTokenOpts) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{}
+	if o.Token != "" {
+		// Mask token for security, show only first 8 chars
+		if len(o.Token) > 8 {
+			params["Token"] = o.Token[:8] + "..."
+		} else {
+			params["Token"] = "***"
+		}
+	}
+	return params
+}
+
 // Execute runs the Grant request.
 func (b *revokeTokenBuilder) Execute() (*PNRevokeTokenResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNAccessManagerRevokeToken, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyPNRevokeTokenResponse, status, err

--- a/set_state_request.go
+++ b/set_state_request.go
@@ -65,8 +65,25 @@ func (b *setStateBuilder) UUID(uuid string) *setStateBuilder {
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *setStateOpts) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"Channels":      o.Channels,
+		"ChannelGroups": o.ChannelGroups,
+	}
+	if o.UUID != "" {
+		params["UUID"] = o.UUID
+	}
+	if o.State != nil {
+		params["State"] = fmt.Sprintf("%v", o.State)
+	}
+	return params
+}
+
 // Execute runs the the Set State request and returns the SetStateResponse
 func (b *setStateBuilder) Execute() (*SetStateResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNSetStateOperation, b.opts.GetLogParams(), true)
+	
 	stateOperation := StateOperation{}
 	stateOperation.channels = b.opts.Channels
 	stateOperation.channelGroups = b.opts.ChannelGroups

--- a/subscribe_request.go
+++ b/subscribe_request.go
@@ -98,8 +98,28 @@ func (b *subscribeBuilder) QueryParam(queryParam map[string]string) *subscribeBu
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *SubscribeOperation) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{
+		"Channels":        o.Channels,
+		"ChannelGroups":   o.ChannelGroups,
+		"PresenceEnabled": o.PresenceEnabled,
+	}
+	if o.Timetoken != 0 {
+		params["Timetoken"] = o.Timetoken
+	}
+	if o.FilterExpression != "" {
+		params["FilterExpression"] = o.FilterExpression
+	}
+	if o.State != nil {
+		params["State"] = fmt.Sprintf("%v", o.State)
+	}
+	return params
+}
+
 // Execute runs the Subscribe operation.
 func (b *subscribeBuilder) Execute() {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNSubscribeOperation, b.operation.GetLogParams(), true)
 	b.opts.pubnub.subscriptionManager.adaptSubscribe(b.operation)
 }
 

--- a/subscription_manager.go
+++ b/subscription_manager.go
@@ -986,10 +986,8 @@ func parseCipherInterface(data interface{}, pubnub *PubNub) (interface{}, error)
 				//decrypt pn_other only
 				msg, ok := v["pn_other"].(string)
 				if ok {
-					pubnub.loggerManager.LogSimple(PNLogLevelTrace, "Crypto: decrypting pn_other field", false)
-					decrypted, errDecryption := decryptString(module, msg)
+					decrypted, errDecryption := decryptString(module, msg, pubnub.loggerManager)
 					if errDecryption != nil {
-						pubnub.loggerManager.LogSimple(PNLogLevelWarn, fmt.Sprintf("Crypto: decryption error, message might be unencrypted: %v", errDecryption), false)
 
 						return v, errDecryption
 					} else {
@@ -1000,8 +998,6 @@ func parseCipherInterface(data interface{}, pubnub *PubNub) (interface{}, error)
 							return intf, err
 						}
 						v["pn_other"] = intf
-
-						pubnub.loggerManager.LogSimple(PNLogLevelTrace, "Crypto: successfully decrypted pn_other", false)
 						return v, nil
 					}
 				}
@@ -1011,16 +1007,12 @@ func parseCipherInterface(data interface{}, pubnub *PubNub) (interface{}, error)
 			return v, nil
 		case string:
 			var intf interface{}
-			pubnub.loggerManager.LogSimple(PNLogLevelTrace, "Crypto: decrypting string message", false)
-			decrypted, errDecryption := decryptString(module, data.(string))
+			decrypted, errDecryption := decryptString(module, data.(string), pubnub.loggerManager)
 			if errDecryption != nil {
-				pubnub.loggerManager.LogSimple(PNLogLevelWarn, fmt.Sprintf("Crypto: decryption error, message might be unencrypted: %v", errDecryption), false)
 
 				intf = data
 				return intf, errDecryption
 			}
-			pubnub.loggerManager.LogSimple(PNLogLevelTrace, "Crypto: decryption successful, unmarshaling JSON", false)
-
 			err := json.Unmarshal([]byte(decrypted.(string)), &intf)
 			if err != nil {
 				pubnub.loggerManager.LogSimple(PNLogLevelWarn, fmt.Sprintf("Serialization: JSON unmarshal error after decryption: %v", err), false)

--- a/subscription_manager_test.go
+++ b/subscription_manager_test.go
@@ -23,7 +23,7 @@ func TestParseCipherInterfaceCipherWithCipher(t *testing.T) {
 	pn.Config.CipherKey = "enigma"
 	pn.Config.UseRandomInitializationVector = false
 
-	intf, err := parseCipherInterface(s, pn.Config, pn.getCryptoModule())
+	intf, err := parseCipherInterface(s, pn)
 
 	assert.Nil(err)
 	assert.Equal("yay!", intf.(string))
@@ -36,7 +36,7 @@ func TestParseCipherInterfacePlainWithCipher(t *testing.T) {
 	pn := NewPubNub(NewDemoConfig())
 	pn.Config.CipherKey = "enigma"
 
-	intf, _ := parseCipherInterface(s, pn.Config, pn.getCryptoModule())
+	intf, _ := parseCipherInterface(s, pn)
 
 	assert.Equal("yay!", intf.(string))
 }
@@ -48,7 +48,7 @@ func TestParseCipherInterfaceCipherWithDiffCipher(t *testing.T) {
 	pn := NewPubNub(NewDemoConfig())
 	pn.Config.CipherKey = "test"
 
-	intf, _ := parseCipherInterface(s, pn.Config, pn.getCryptoModule())
+	intf, _ := parseCipherInterface(s, pn)
 
 	assert.Equal("Wi24KS4pcTzvyuGOHubiXg==", intf.(string))
 
@@ -61,7 +61,7 @@ func TestParseCipherInterfacePlainWithDiffCipher(t *testing.T) {
 	pn := NewPubNub(NewDemoConfig())
 	pn.Config.CipherKey = "test"
 
-	intf, _ := parseCipherInterface(s, pn.Config, pn.getCryptoModule())
+	intf, _ := parseCipherInterface(s, pn)
 
 	assert.Equal("yay!", intf.(string))
 }
@@ -73,7 +73,7 @@ func TestParseCipherInterfaceCipherWithoutCipher(t *testing.T) {
 	pn := NewPubNub(NewDemoConfig())
 	pn.Config.CipherKey = ""
 
-	intf, _ := parseCipherInterface(s, pn.Config, pn.getCryptoModule())
+	intf, _ := parseCipherInterface(s, pn)
 
 	assert.Equal("Wi24KS4pcTzvyuGOHubiXg==", intf.(string))
 }
@@ -85,7 +85,7 @@ func TestParseCipherInterfacePlainWithoutCipher(t *testing.T) {
 	pn := NewPubNub(NewDemoConfig())
 	pn.Config.CipherKey = ""
 
-	intf, _ := parseCipherInterface(s, pn.Config, pn.getCryptoModule())
+	intf, _ := parseCipherInterface(s, pn)
 
 	assert.Equal("yay!", intf.(string))
 }
@@ -100,7 +100,7 @@ func TestParseCipherInterfacePlainWithCipherStruct(t *testing.T) {
 	pn := NewPubNub(NewDemoConfig())
 	pn.Config.CipherKey = "enigma"
 
-	intf, err := parseCipherInterface(s, pn.Config, pn.getCryptoModule())
+	intf, err := parseCipherInterface(s, pn)
 
 	assert.Nil(err)
 	if msg, ok := intf.(customStruct); !ok {
@@ -122,7 +122,7 @@ func TestParseCipherInterfacePlainWithoutCipherStruct(t *testing.T) {
 	pn := NewPubNub(NewDemoConfig())
 	pn.Config.CipherKey = ""
 
-	intf, err := parseCipherInterface(s, pn.Config, pn.getCryptoModule())
+	intf, err := parseCipherInterface(s, pn)
 
 	assert.Nil(err)
 	if msg, ok := intf.(customStruct); !ok {
@@ -149,7 +149,7 @@ func TestParseCipherInterfacePlainWithCipherMapPNOther(t *testing.T) {
 	pn := NewPubNub(NewDemoConfig())
 	pn.Config.CipherKey = "enigma"
 
-	intf, _ := parseCipherInterface(s, pn.Config, pn.getCryptoModule())
+	intf, _ := parseCipherInterface(s, pn)
 
 	msg := intf.(map[string]interface{})
 	assert.Equal("12345", msg["not_other"])
@@ -175,7 +175,7 @@ func TestParseCipherInterfacePlainWithoutCipherMapPNOther(t *testing.T) {
 	pn := NewPubNub(NewDemoConfig())
 	pn.Config.CipherKey = ""
 
-	intf, _ := parseCipherInterface(s, pn.Config, pn.getCryptoModule())
+	intf, _ := parseCipherInterface(s, pn)
 
 	msg := intf.(map[string]interface{})
 	assert.Equal("12345", msg["not_other"])
@@ -197,7 +197,7 @@ func TestParseCipherInterfaceCipherWithoutCipherStringPNOther(t *testing.T) {
 	pn := NewPubNub(NewDemoConfig())
 	pn.Config.CipherKey = ""
 
-	intf, _ := parseCipherInterface(s, pn.Config, pn.getCryptoModule())
+	intf, _ := parseCipherInterface(s, pn)
 
 	msg := intf.(map[string]interface{})
 	assert.Equal("1234", msg["not_other"])
@@ -220,7 +220,7 @@ func TestParseCipherInterfaceCipherWithCipherStringPNOther(t *testing.T) {
 	pn.Config.CipherKey = "enigma"
 	pn.Config.UseRandomInitializationVector = false
 
-	intf, _ := parseCipherInterface(s, pn.Config, pn.getCryptoModule())
+	intf, _ := parseCipherInterface(s, pn)
 
 	msg := intf.(map[string]interface{})
 	assert.Equal("1234", msg["not_other"])
@@ -239,7 +239,7 @@ func TestParseCipherInterfaceCipherWithoutCipherStruct(t *testing.T) {
 	pn.Config.CipherKey = "enigma"
 	pn.Config.UseRandomInitializationVector = false
 
-	intf, _ := parseCipherInterface(s, pn.Config, pn.getCryptoModule())
+	intf, _ := parseCipherInterface(s, pn)
 	msg := intf.(map[string]interface{})
 	assert.Equal("hi!", msg["Foo"])
 
@@ -257,7 +257,7 @@ func TestParseCipherInterfaceCipherWithCipherStructPNOther(t *testing.T) {
 	pn.Config.CipherKey = "enigma"
 	pn.Config.UseRandomInitializationVector = false
 
-	intf, _ := parseCipherInterface(s, pn.Config, pn.getCryptoModule())
+	intf, _ := parseCipherInterface(s, pn)
 
 	msg := intf.(map[string]interface{})
 	assert.Equal("1234", msg["not_other"])
@@ -279,7 +279,7 @@ func TestParseCipherInterfaceCipherWithOtherCipherStructPNOther(t *testing.T) {
 	pn := NewPubNub(NewDemoConfig())
 	pn.Config.CipherKey = "test"
 
-	intf, _ := parseCipherInterface(s, pn.Config, pn.getCryptoModule())
+	intf, _ := parseCipherInterface(s, pn)
 
 	msg := intf.(map[string]interface{})
 	assert.Equal("1234", msg["not_other"])
@@ -299,7 +299,7 @@ func TestParseCipherInterfaceCipherWithCipherStructPNOtherDisable(t *testing.T) 
 	pn.Config.UseRandomInitializationVector = false
 	pn.Config.CipherKey = "enigma"
 
-	intf, _ := parseCipherInterface(s, pn.Config, pn.getCryptoModule())
+	intf, _ := parseCipherInterface(s, pn)
 
 	msg := intf.(map[string]interface{})
 	assert.Equal("1234", msg["not_other"])
@@ -315,7 +315,7 @@ func TestParseCipherInterfaceCipherWithIntSlice(t *testing.T) {
 	pn.Config.DisablePNOtherProcessing = true
 	pn.Config.CipherKey = ""
 
-	intf, _ := parseCipherInterface(s, pn.Config, pn.getCryptoModule())
+	intf, _ := parseCipherInterface(s, pn)
 
 	msg := intf.([]int)
 	assert.Equal(1, msg[0])
@@ -330,7 +330,7 @@ func TestParseCipherInterfaceCipherWithoutCipherStruct2(t *testing.T) {
 	pn.Config.CipherKey = "enigma"
 	pn.Config.UseRandomInitializationVector = false
 
-	intf, _ := parseCipherInterface(s, pn.Config, pn.getCryptoModule())
+	intf, _ := parseCipherInterface(s, pn)
 	msg := intf.(map[string]interface{})
 	assert.Equal("12345", msg["not_other"])
 	if msgOther, ok := msg["pn_other"].(map[string]interface{}); !ok {
@@ -618,7 +618,7 @@ func TestDecryptionProcessOnEncryptedMessage(t *testing.T) {
 	pn.Config.CryptoModule = crypto
 
 	// Rust generated cipher text
-	result, err := parseCipherInterface("UE5FRAFBQ1JIEALf+E65kseYJwTw2J6BUk9MePHiCcBCS+8ykXLkBIOA", pn.Config, pn.getCryptoModule())
+	result, err := parseCipherInterface("UE5FRAFBQ1JIEALf+E65kseYJwTw2J6BUk9MePHiCcBCS+8ykXLkBIOA", pn)
 
 	assert.Nil(err)
 	assert.Equal("test", result)
@@ -633,7 +633,7 @@ func TestDecryptionProcessOnNoEncryptedMessage(t *testing.T) {
 
 	pn.Config.CryptoModule = crypto
 
-	result, err := parseCipherInterface("test", pn.Config, pn.getCryptoModule())
+	result, err := parseCipherInterface("test", pn)
 
 	assert.NotNil(err)
 	assert.Equal("test", result)

--- a/time_request.go
+++ b/time_request.go
@@ -44,8 +44,15 @@ func (b *timeBuilder) QueryParam(queryParam map[string]string) *timeBuilder {
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *timeOpts) GetLogParams() map[string]interface{} {
+	return map[string]interface{}{} // No user parameters for Time operation
+}
+
 // Execute runs the Time request and fetches the time from the server.
 func (b *timeBuilder) Execute() (*TimeResponse, StatusResponse, error) {
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNTimeOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyTimeResp, status, err

--- a/unsubscribe_builder.go
+++ b/unsubscribe_builder.go
@@ -35,7 +35,16 @@ func (b *unsubscribeBuilder) QueryParam(queryParam map[string]string) *unsubscri
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *UnsubscribeOperation) GetLogParams() map[string]interface{} {
+	return map[string]interface{}{
+		"Channels":      o.Channels,
+		"ChannelGroups": o.ChannelGroups,
+	}
+}
+
 // Execute runs the Unsubscribe request and unsubscribes from the specified channels.
 func (b *unsubscribeBuilder) Execute() {
+	b.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNUnsubscribeOperation, b.operation.GetLogParams(), true)
 	b.pubnub.subscriptionManager.adaptUnsubscribe(b.operation)
 }

--- a/where_now_request.go
+++ b/where_now_request.go
@@ -53,12 +53,23 @@ func (b *whereNowBuilder) Transport(tr http.RoundTripper) *whereNowBuilder {
 	return b
 }
 
+// GetLogParams returns the user-provided parameters for logging
+func (o *whereNowOpts) GetLogParams() map[string]interface{} {
+	params := map[string]interface{}{}
+	if o.UUID != "" {
+		params["UUID"] = o.UUID
+	}
+	return params
+}
+
 // Execute runs the WhereNow request.
 func (b *whereNowBuilder) Execute() (*WhereNowResponse, StatusResponse, error) {
 	if len(b.opts.UUID) <= 0 {
 		b.opts.UUID = b.opts.pubnub.Config.UUID
 	}
 
+	b.opts.pubnub.loggerManager.LogUserInput(PNLogLevelDebug, PNWhereNowOperation, b.opts.GetLogParams(), true)
+	
 	rawJSON, status, err := executeRequest(b.opts)
 	if err != nil {
 		return emptyWhereNowResponse, status, err


### PR DESCRIPTION
feat(logging): Add advanced logging system with multiple logger support

Add new logging system with `LoggerManager` supporting multiple custom loggers, structured log message types (network requests/responses, errors, user inputs), and PNLogger interface. Includes `DefaultLogger` with configurable log levels and detailed SDK operation logging. The new Config.Loggers field replaces deprecated Config.Log while maintaining backward compatibility.

refactor(logging): Refactor logs across all files

Refactor logs across the whole SDK. Now logs have dedicated structure and type, so only intended type will be printed. There is now much more logs, especially in internal systems.

refactor(logging): Deprecate the old Logger

Deprecate the old Logger. The old logger is still working (for backward compatibility) and is default to `PNLogLevelDebug`.